### PR TITLE
Trailing comma setting adjustment

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,7 +3,7 @@
   "printWidth": 80,
   "tabWidth": 2,
   "singleQuote": false,
-  "trailingComma": "all",
+  "trailingComma": "es5",
   "parser": "babylon",
   "semi": true,
   "quoteProps": "consistent"

--- a/source/code-snippets/usage-examples/replaceOne.js
+++ b/source/code-snippets/usage-examples/replaceOne.js
@@ -40,7 +40,7 @@ async function run() {
       }
       if (result.upsertedCount === 1) {
         console.log(
-          "Inserted one new document with an _id of " + result.upsertedId._id,
+          "Inserted one new document with an _id of " + result.upsertedId._id
         );
       }
     }


### PR DESCRIPTION
Our current configuration enforces trailing commas on multi-line constructions. I would suggest that we continue to enforce trailing commas on objects, but omit them from function calls. See my second commit for an example of how trailing commas on function calls can have slightly baffling results.