### PR TITLE
Typos and cleanup branch

### DIFF
--- a/source/fundamentals/crud/read-operations/text.txt
+++ b/source/fundamentals/crud/read-operations/text.txt
@@ -14,7 +14,7 @@ Overview
 
 Text searches let you search a collection of string-valued fields for
 words or phrases, instead of matching substrings like
-:mdn:`regular expresssions
+:mdn:`regular expressions
 <Web/JavaScript/Guide/Regular_Expressions>`,
 also known as RegEx. While regex is very powerful, and MongoDB even
 offers a `$regex <>` operator, text searches work particularly well when

--- a/source/usage-examples/bulkWrite.txt
+++ b/source/usage-examples/bulkWrite.txt
@@ -4,9 +4,6 @@ Perform Bulk Operations
 
 .. default-domain:: mongodb
 
-Overview
---------
-
 :node-api:`collection.bulkWrite <Collection.html#bulkWrite>` lets you
 perform bulk write operations against a *single* collection. With
 ``collection.bulkWrite()``, you specify a list of operations to perform

--- a/source/usage-examples/command.txt
+++ b/source/usage-examples/command.txt
@@ -4,9 +4,6 @@ Run a Command
 
 .. default-domain:: mongodb
 
-Overview
---------
-
 You can run all raw database operations, not including
 :manual:`CRUD </crud/>` operations, using the :node-api:`command()
 <Admin.html#~command>` method. Typically ``command()`` is used for

--- a/source/usage-examples/count.txt
+++ b/source/usage-examples/count.txt
@@ -4,9 +4,6 @@ Count Documents
 
 .. default-domain:: mongodb
 
-Overview
---------
-
 The Node.js driver provides two methods for counting
 documents in a collection:
 

--- a/source/usage-examples/deleteMany.txt
+++ b/source/usage-examples/deleteMany.txt
@@ -4,9 +4,6 @@ Delete Multiple Documents
 
 .. default-domain:: mongodb
 
-Overview
---------
-
 You can delete several documents in a collection at once with
 ``collection.deleteMany()``.
 The ``deleteMany()`` method uses a query document that you provide

--- a/source/usage-examples/deleteOne.txt
+++ b/source/usage-examples/deleteOne.txt
@@ -4,9 +4,6 @@ Delete a Document
 
 .. default-domain:: mongodb
 
-Overview
---------
-
 You can delete a single document in a collection with
 ``collection.deleteOne()``.
 The ``deleteOne()`` method uses a query document that you provide

--- a/source/usage-examples/find.txt
+++ b/source/usage-examples/find.txt
@@ -4,9 +4,6 @@ Find Multiple Documents
 
 .. default-domain:: mongodb
 
-Overview
---------
-
 You can
 :doc:`query </fundamentals/crud/query-document>`
 for multiple documents in a collection with ``collection.find()``.

--- a/source/usage-examples/findOne.txt
+++ b/source/usage-examples/findOne.txt
@@ -4,9 +4,6 @@ Find a Document
 
 .. default-domain:: mongodb
 
-Overview
---------
-
 You can
 :manual:`query </tutorial/query-documents/#read-operations-query-argument>`
 for a single document in a collection with ``collection.findOne()``.


### PR DESCRIPTION
Stage:
------
https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/Typos-And-Cleanup-Branch/

Changes:
-----------
* removed "Overview" header from all usage examples, they are inconsistently in some of the usage examples and not in others. That header should not be there at all
* Fixed typo in `source/fundamentals/crud/read-operations/text.txt`