### PR TITLE
Standardized example header in usage examples

### DIFF
--- a/source/usage-examples/command.txt
+++ b/source/usage-examples/command.txt
@@ -28,6 +28,8 @@ The ``command()`` method returns a :mdn:`Promise
 that resolves to an object containing the return object of the operation
 that was run.
 
+Example
+-------
 
 .. literalinclude:: /code-snippets/usage-examples/command.js
   :language: javascript

--- a/source/usage-examples/distinct.txt
+++ b/source/usage-examples/distinct.txt
@@ -39,7 +39,6 @@ resembles the following:
 
    "key" had the wrong type. Expected string, found <non-string type>
 
-
 Example
 -------
 

--- a/source/usage-examples/insertMany.txt
+++ b/source/usage-examples/insertMany.txt
@@ -24,6 +24,9 @@ Specifying incorrect parameters for your ``insertMany()`` operation can
 cause problems. Attempting to insert a field to a value that would violate
 unique index rules will throw a ``duplicate key error``.
 
+Example
+-------
+
 .. literalinclude:: /code-snippets/usage-examples/insertMany.js
   :language: javascript
   :linenos:

--- a/source/usage-examples/insertOne.txt
+++ b/source/usage-examples/insertOne.txt
@@ -17,6 +17,9 @@ inserted document. The ``insertedCount`` field of this object has a
 value of ``0`` if a document was not created, and a value of ``1`` if a
 document was created.
 
+Example
+-------
+
 .. literalinclude:: /code-snippets/usage-examples/insertOne.js
   :language: javascript
   :linenos:

--- a/source/usage-examples/replaceOne.txt
+++ b/source/usage-examples/replaceOne.txt
@@ -41,6 +41,9 @@ unique index rule, ``replaceOne()`` throws a ``duplicate key error``.
   You can configure ``findOneAndReplace()`` to return either the
   original matched document or the replacement document.
 
+Example
+-------
+
 .. literalinclude:: /code-snippets/usage-examples/replaceOne.js
   :language: javascript
   :linenos:

--- a/source/usage-examples/updateMany.txt
+++ b/source/usage-examples/updateMany.txt
@@ -18,6 +18,9 @@ The ``updateMany()`` method returns a :mdn:`Promise
 that resolves to an object. The ``modifiedCount`` field of this object
 shows how many documents were modified.
 
+Example
+-------
+
 .. literalinclude:: /code-snippets/usage-examples/updateMany.js
   :language: javascript
   :linenos:

--- a/source/usage-examples/updateOne.txt
+++ b/source/usage-examples/updateOne.txt
@@ -28,10 +28,6 @@ cause problems. Attempting to modify the immutable field ``_id`` will
 result in an error. Additionally, trying to update a field to value that
 would violate unique index rules will throw a ``duplicate key error``.
 
-.. literalinclude:: /code-snippets/usage-examples/updateOne.js
-  :language: javascript
-  :linenos:
-
 .. note::
 
   If your application requires the document after updating,
@@ -39,3 +35,11 @@ would violate unique index rules will throw a ``duplicate key error``.
   <api/Collection.html#findOneAndUpdate>`. method, which has a similar
   interface to ``updateOne()`` but also returns the original or updated
   document.
+
+Example
+-------
+
+.. literalinclude:: /code-snippets/usage-examples/updateOne.js
+  :language: javascript
+  :linenos:
+


### PR DESCRIPTION
Stage: https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker/ExampleHeader/usage-examples/overview

Not all usage examples contain an "Example" header above the actual code example. Added this to the examples that lacked it, since the majority contain it.