### PR TITLE
standardizing change stream example with other usage exs

### DIFF
--- a/source/api-documentation.txt
+++ b/source/api-documentation.txt
@@ -1,7 +1,0 @@
-=================
-API Documentation
-=================
-
-.. default-domain:: mongodb
-
-:node-api:`API <>`

--- a/source/code-snippets/usage-examples/bulkWrite-example.js
+++ b/source/code-snippets/usage-examples/bulkWrite-example.js
@@ -1,11 +1,11 @@
 const { MongoClient } = require("mongodb");
 const fs = require("fs");
 
-// Replace the following string with your MongoDB deployment's connection string.
+// Replace the uri string with your MongoDB deployment's connection string.
 const uri =
-  "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority";
+  "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority&useUnifiedTopology=true";
 
-const client = new MongoClient(uri, { useUnifiedTopology: true });
+const client = new MongoClient(uri);
 
 async function run() {
   try {
@@ -40,7 +40,7 @@ async function run() {
           console.log("Number of documents inserted: " + result.nInserted);
         } else {
           console.log(
-            "No documents were inserted during the bulk write operation"
+            "No documents were inserted during the bulk write operation",
           );
         }
 

--- a/source/code-snippets/usage-examples/command.js
+++ b/source/code-snippets/usage-examples/command.js
@@ -1,11 +1,11 @@
 // ignored first line
 const { MongoClient } = require("mongodb");
 
-// Replace the following string with your MongoDB deployment's connection string.
+// Replace the uri string with your MongoDB deployment's connection string.
 const uri =
-  "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority";
+  "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority&useUnifiedTopology=true";
 
-const client = new MongoClient(uri, { useUnifiedTopology: true });
+const client = new MongoClient(uri);
 
 async function run() {
   try {

--- a/source/code-snippets/usage-examples/count.js
+++ b/source/code-snippets/usage-examples/count.js
@@ -1,11 +1,11 @@
 // ignored first line
 const { MongoClient } = require("mongodb");
 
-// Replace the following string with your MongoDB deployment's connection string.
+// Replace the uri string with your MongoDB deployment's connection string.
 const uri =
-  "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority";
+  "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority&useUnifiedTopology=true";
 
-const client = new MongoClient(uri, { useUnifiedTopology: true });
+const client = new MongoClient(uri);
 
 async function run() {
   try {

--- a/source/code-snippets/usage-examples/deleteMany.js
+++ b/source/code-snippets/usage-examples/deleteMany.js
@@ -1,11 +1,11 @@
 // ignored first line
 const { MongoClient } = require("mongodb");
 
-// Replace the following string with your MongoDB deployment's connection string.
+// Replace the uri string with your MongoDB deployment's connection string.
 const uri =
-  "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority";
+  "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority&useUnifiedTopology=true";
 
-const client = new MongoClient(uri, { useUnifiedTopology: true });
+const client = new MongoClient(uri);
 
 async function run() {
   try {

--- a/source/code-snippets/usage-examples/deleteOne.js
+++ b/source/code-snippets/usage-examples/deleteOne.js
@@ -1,11 +1,11 @@
 // ignored first line
 const { MongoClient } = require("mongodb");
 
-// Replace the following string with your MongoDB deployment's connection string.
+// Replace the uri string with your MongoDB deployment's connection string.
 const uri =
-  "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority";
+  "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority&useUnifiedTopology=true";
 
-const client = new MongoClient(uri, { useUnifiedTopology: true });
+const client = new MongoClient(uri);
 
 async function run() {
   try {

--- a/source/code-snippets/usage-examples/distinct.js
+++ b/source/code-snippets/usage-examples/distinct.js
@@ -1,11 +1,11 @@
 // ignored first line
 const { MongoClient } = require("mongodb");
 
-// Replace the following string with your MongoDB deployment's connection string.
+// Replace the uri string with your MongoDB deployment's connection string.
 const uri =
-  "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority";
+  "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority&useUnifiedTopology=true";
 
-const client = new MongoClient(uri, { useUnifiedTopology: true });
+const client = new MongoClient(uri);
 
 async function run() {
   try {

--- a/source/code-snippets/usage-examples/find.js
+++ b/source/code-snippets/usage-examples/find.js
@@ -1,11 +1,11 @@
 // ignored first line
 const { MongoClient } = require("mongodb");
 
-// Replace the following string with your MongoDB deployment's connection string.
+// Replace the uri string with your MongoDB deployment's connection string.
 const uri =
-  "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority";
+  "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority&useUnifiedTopology=true";
 
-const client = new MongoClient(uri, { useUnifiedTopology: true });
+const client = new MongoClient(uri);
 
 async function run() {
   try {

--- a/source/code-snippets/usage-examples/findOne.js
+++ b/source/code-snippets/usage-examples/findOne.js
@@ -1,11 +1,11 @@
 // ignored first line
 const { MongoClient } = require("mongodb");
 
-// Replace the following string with your MongoDB deployment's connection string.
+// Replace the uri string with your MongoDB deployment's connection string.
 const uri =
-  "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority";
+  "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority&useUnifiedTopology=true";
 
-const client = new MongoClient(uri, { useUnifiedTopology: true });
+const client = new MongoClient(uri);
 
 async function run() {
   try {

--- a/source/code-snippets/usage-examples/insertMany.js
+++ b/source/code-snippets/usage-examples/insertMany.js
@@ -1,11 +1,11 @@
 // ignored first line
 const { MongoClient } = require("mongodb");
 
-// Replace the following string with your MongoDB deployment's connection string.
+// Replace the uri string with your MongoDB deployment's connection string.
 const uri =
-  "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority";
+  "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority&useUnifiedTopology=true";
 
-const client = new MongoClient(uri, { useUnifiedTopology: true });
+const client = new MongoClient(uri);
 
 async function run() {
   try {

--- a/source/code-snippets/usage-examples/insertOne.js
+++ b/source/code-snippets/usage-examples/insertOne.js
@@ -1,11 +1,11 @@
 // ignored first line
 const { MongoClient } = require("mongodb");
 
-// Replace the following string with your MongoDB deployment's connection string.
+// Replace the uri string with your MongoDB deployment's connection string.
 const uri =
-  "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority";
+  "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority&useUnifiedTopology=true";
 
-const client = new MongoClient(uri, { useUnifiedTopology: true });
+const client = new MongoClient(uri);
 
 async function run() {
   try {

--- a/source/code-snippets/usage-examples/replaceOne.js
+++ b/source/code-snippets/usage-examples/replaceOne.js
@@ -1,11 +1,11 @@
 // ignored first line
 const { MongoClient } = require("mongodb");
 
-// Replace the following string with your MongoDB deployment's connection string.
+// Replace the uri string with your MongoDB deployment's connection string.
 const uri =
-  "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority";
+  "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority&useUnifiedTopology=true";
 
-const client = new MongoClient(uri, { useUnifiedTopology: true });
+const client = new MongoClient(uri);
 
 async function run() {
   try {

--- a/source/code-snippets/usage-examples/updateMany.js
+++ b/source/code-snippets/usage-examples/updateMany.js
@@ -1,11 +1,11 @@
 // ignored first line
 const { MongoClient } = require("mongodb");
 
-// Replace the following string with your MongoDB deployment's connection string.
+// Replace the uri string with your MongoDB deployment's connection string.
 const uri =
-  "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority";
+  "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority&useUnifiedTopology=true";
 
-const client = new MongoClient(uri, { useUnifiedTopology: true });
+const client = new MongoClient(uri);
 
 async function run() {
   try {

--- a/source/code-snippets/usage-examples/updateOne.js
+++ b/source/code-snippets/usage-examples/updateOne.js
@@ -1,11 +1,11 @@
 // ignored first line
 const { MongoClient } = require("mongodb");
 
-// Replace the following string with your MongoDB deployment's connection string.
+// Replace the uri string with your MongoDB deployment's connection string.
 const uri =
-  "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority";
+  "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority&useUnifiedTopology=true";
 
-const client = new MongoClient(uri, { useUnifiedTopology: true });
+const client = new MongoClient(uri);
 
 async function run() {
   try {

--- a/source/index.txt
+++ b/source/index.txt
@@ -13,7 +13,7 @@ MongoDB Node Driver
   /quick-start
   /fundamentals
   /usage-examples
-  API Documentation <http://mongodb.github.io/node-mongodb-native/3.5/api>
+  API Documentation <http://mongodb.github.io/node-mongodb-native/3.5/api/>
   /faq
   /issues-and-help
   /compatibility

--- a/source/index.txt
+++ b/source/index.txt
@@ -13,7 +13,7 @@ MongoDB Node Driver
   /quick-start
   /fundamentals
   /usage-examples
-  /api-documentation
+  API Documentation :node-api:`API <>`
   /faq
   /issues-and-help
   /compatibility
@@ -28,7 +28,7 @@ connect to MongoDB and work with data.
 
    These docs are for version 3.5 of the MongoDB Node.js driver. If
    you're looking for an older version of the MongoDB Node.js driver
-   docs, :node-docs:`see the Legacy Node.js driver documentation </>`.
+   docs, :node-docs:`see the Legacy Node.js driver documentation <>`.
    For the main MongoDB documentation, see the :manual:`MongoDB Manual
    </>`.
 

--- a/source/index.txt
+++ b/source/index.txt
@@ -13,7 +13,7 @@ MongoDB Node Driver
   /quick-start
   /fundamentals
   /usage-examples
-  MongoDB Stitch <https://docs.mongodb.com/stitch/>
+  API Documentation <http://mongodb.github.io/node-mongodb-native/3.5/api>
   /faq
   /issues-and-help
   /compatibility

--- a/source/index.txt
+++ b/source/index.txt
@@ -13,7 +13,7 @@ MongoDB Node Driver
   /quick-start
   /fundamentals
   /usage-examples
-  API Documentation :node-api:`API <>`
+  MongoDB Stitch <https://docs.mongodb.com/stitch/>
   /faq
   /issues-and-help
   /compatibility

--- a/source/usage-examples/changeStream.txt
+++ b/source/usage-examples/changeStream.txt
@@ -9,59 +9,59 @@ Open a Change Stream
 
 You can keep track of changes to data in MongoDB, such as changes to a
 collection, database, or deployment, by opening a :manual:`Change
-Stream</changeStreams/>`. A ``Change Stream`` allows applications to
+Stream</changeStreams/>`. A Change Stream allows applications to
 watch for changes to data and react to those changes. You can open a
-``Change Stream`` by calling the :node-api:`Collection.watch()
+Change Stream by calling the :node-api:`Collection.watch()
 </Collection.html#watch>`, :node-api:`Db.watch() </Db.html#watch>`, or
 :node-api:`MongoClient.watch()</MongoClient.html#watch>`  method.
 
 The ``watch()`` method  optionally takes a :manual:`pipeline
 </reference/operator/aggregation-pipeline/>`, an array of
 :manual:`stages </changeStreams/#modify-change-stream-output>`, as the
-first parameter to filter the :manual:`change events
-</reference/change-events/>` output. Also, ``watch()`` can take an
-additional options object as the second parameter. Set the
-``fullDocument`` field of the additional options object to the string 
-``"updateLookup"`` to receive an event that contains the changes to the
-document as well as the entire altered document. Alternatively, you can
-set ``fullDocument`` to the string ``"default"`` to only receive the
-altered document, but not the changes to the document. 
+first parameter to filter and transform the :manual:`change events
+</reference/change-events/>` output. ``watch()`` accepts an additional
+options object as the second parameter. By default, change streams only
+return the fields modified by an update operation, instead of the entire
+updated document. You can configure your Change Stream to also
+return the most current version of a document by setting the
+``fullDocument`` field of the options object to ``"updateLookup"``.
 
 Process the Change Stream Events
 --------------------------------
 
-You can capture events from a ``Change Stream`` instance by using a listener
-function. Call the ``watch()`` command to get a ``Change Stream`` instance. Add
-your listener function by calling the `EventEmitter.on()
+You can capture events from a Change Stream with a listener
+function. Call the ``watch()`` command to get a ``ChangeStream`` instance.
+Add your listener function by calling the `EventEmitter.on()
 <https://nodejs.org/api/events.html#events_emitter_on_eventname_listener>`_
-method on that instance. Set the value of the first parameter to the
-string ``'change'`` and add your :mdn:`callback function
-<Glossary/Callback_function>` as the second parameter.  The callback
-triggers when a ``change event`` is emitted, providing the next available
-document. You can specify logic in the callback to process the event
-document when it is received. 
+method on that instance. Pass the string ``change`` as the first parameter
+and add your :mdn:`callback function <Glossary/Callback_function>` as
+the second parameter.  The callback triggers when a change event is
+emitted, providing the next available document. You can specify logic in
+the callback to process the event document when it is received.
 
 Call the :node-api:`close() </ChangeStream.html#close>` method on the
-``Change Stream`` instance to stop processing ``change events``. This method
-closes the ``Change Stream`` and frees resources.
+``ChangeStream`` instance to stop processing change events. This method
+closes the Change Stream and frees resources.
 
 Example
 -------
 
-The following example opens a ``Change Stream`` on the ``movies``
+The following example opens a Change Stream on the ``movies``
 collection. We create a listener function to receive and print change
-events that occur. 
+events that occur.
 
-To emit a ``change event``, we perform a change to the collection, such as
+To emit a change event, we perform a change to the collection, such as
 insertion with ``insertOne()``. To prevent ``insertOne()`` from
 executing before the listener function can register, we create a timer
-that uses :mdn:`setTimeout
-<Web/API/WindowOrWorkerGlobalScope/setTimeout>` to wait 1 second. When
-you insert a document, the listener receives the corresponding event.
+that uses :mdn:`setTimeout <Web/API/WindowOrWorkerGlobalScope/setTimeout>`
+to wait 1 second. When you insert a document, the listener receives the
+corresponding event.
 
 After that, we create a second timer to wait an additional second after
-the insertion of the document to close the ``Change Stream`` instance
+the insertion of the document to close the ``ChangeStream`` instance
 using ``changeStream.close()``.
+
+.. include:: /includes/connect-guide-note.rst
 
 .. literalinclude:: /code-snippets/usage-examples/changeStream.js
   :language: javascript :linenos:

--- a/source/usage-examples/changeStream.txt
+++ b/source/usage-examples/changeStream.txt
@@ -8,10 +8,10 @@ Open a Change Stream
 --------------------
 
 You can keep track of changes to data in MongoDB, such as changes to a
-collection, database, or deployment, by opening a :manual:`Change
-Stream</changeStreams/>`. A Change Stream allows applications to
+collection, database, or deployment, by opening a :manual:`change
+stream</changeStreams/>`. A change stream allows applications to
 watch for changes to data and react to those changes. You can open a
-Change Stream by calling the :node-api:`Collection.watch()
+change stream by calling the :node-api:`Collection.watch()
 </Collection.html#watch>`, :node-api:`Db.watch() </Db.html#watch>`, or
 :node-api:`MongoClient.watch()</MongoClient.html#watch>`  method.
 
@@ -22,14 +22,14 @@ first parameter to filter and transform the :manual:`change events
 </reference/change-events/>` output. ``watch()`` accepts an additional
 options object as the second parameter. By default, change streams only
 return the fields modified by an update operation, instead of the entire
-updated document. You can configure your Change Stream to also
+updated document. You can configure your change stream to also
 return the most current version of a document by setting the
 ``fullDocument`` field of the options object to ``"updateLookup"``.
 
 Process the Change Stream Events
 --------------------------------
 
-You can capture events from a Change Stream with a listener
+You can capture events from a change stream with a listener
 function. Call the ``watch()`` command to get a ``ChangeStream`` instance.
 Add your listener function by calling the `EventEmitter.on()
 <https://nodejs.org/api/events.html#events_emitter_on_eventname_listener>`_
@@ -41,12 +41,12 @@ the callback to process the event document when it is received.
 
 Call the :node-api:`close() </ChangeStream.html#close>` method on the
 ``ChangeStream`` instance to stop processing change events. This method
-closes the Change Stream and frees resources.
+closes the change stream and frees resources.
 
 Example
 -------
 
-The following example opens a Change Stream on the ``movies``
+The following example opens a change stream on the ``movies``
 collection. We create a listener function to receive and print change
 events that occur.
 


### PR DESCRIPTION
- added note linking users to the connection guide above the usage example snippet
- updated ``fullDocument`` field documentation to match the definition found [here](https://docs.mongodb.com/manual/reference/method/db.collection.watch/) (subtle differences in interpretation -- this definition matches my own testing)
- limited usage of monospace font to specific coding terms

Staging: https://docs-mongodbcom-staging.corp.mongodb.com/ce3554b/node/docsworker/standardization/usage-examples/changeStream