### PR TITLE
fix link to collations on index page

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -67,8 +67,8 @@ material on using the Node.js driver for the following:
 * :doc:`Indexes </fundamentals/indexes>`: create and design indexes to make
   your queries efficient
 
-* :doc:`Collations </fundamentals/indexes>`: apply
-  language-specific sorting rules to your query results
+* :doc:`Collations </fundamentals/collations>`: apply language-specific 
+  sorting rules to your query results
 
 * :doc:`Logging </fundamentals/logging>`: configure the driver to log
   MongoDB operations


### PR DESCRIPTION
No JIRA

Staging:
https://docs-mongodborg-staging.corp.mongodb.com/9c1217d/node/docsworker-xlarge/index-typo-fix-022820/