### PR TITLE
DOCSP-9539: remove mention of errmsg from delete operations

### DIFF
--- a/source/usage-examples/deleteMany.txt
+++ b/source/usage-examples/deleteMany.txt
@@ -37,9 +37,6 @@ contains multiple keys in the event of a successful
 execution. You can use the ``deletedCount`` key to determine the number
 of documents deleted by the operation.
 
-The error object contains ``errmsg``, a human-readable explanation of
-what caused the operation to fail.
-
 Example
 -------
 

--- a/source/usage-examples/deleteOne.txt
+++ b/source/usage-examples/deleteOne.txt
@@ -37,9 +37,6 @@ use the ``deletedCount`` key to check the number of documents deleted by
 the operation. Since ``deleteOne()`` can only delete a single document,
 ``deletedCount`` can have a value of either ``0`` or ``1``.
 
-The error object contains ``errmsg``, a human-readable explanation of
-what caused the operation to fail.
-
 .. note::
 
   If your application requires the deleted document after deletion,


### PR DESCRIPTION
JIRA:
https://jira.mongodb.org/browse/DOCSP-9539

Staging:
https://docs-mongodbcom-staging.corp.mongodb.com/06ff5de/node/docsworker-xlarge/DOCSP-9539-fix-delete-one-many/usage-examples/deleteOne

and

https://docs-mongodbcom-staging.corp.mongodb.com/06ff5de/node/docsworker-xlarge/DOCSP-9539-fix-delete-one-many/usage-examples/deleteMany