### PR TITLE
fix typo in findOne usage example

### DIFF
--- a/source/usage-examples/findOne.txt
+++ b/source/usage-examples/findOne.txt
@@ -32,7 +32,7 @@ in the ``options`` object passed as the second parameter of the
 Example
 -------
 
-The following snippet find a single document from the ``movies``
+The following snippet finds a single document from the ``movies``
 collection. It uses the following:
 
 - A **query document** that configures the query to return only


### PR DESCRIPTION
Grammar fix.
find -> finds

JIRA:
None

Staging:
https://docs-mongodbcom-staging.corp.mongodb.com/21393e5/node/docsworker-xlarge/040820-typo-fix/usage-examples/findOne