### PR TITLE
DOCSP-11514: add links to read and write operation non-landing pages

### DIFF
--- a/source/fundamentals/crud/read-operations.txt
+++ b/source/fundamentals/crud/read-operations.txt
@@ -4,6 +4,15 @@ Read Operations
 
 .. default-domain:: mongodb
 
+- :doc:`/fundamentals/crud/read-operations/retrieve`
+- :doc:`/fundamentals/crud/read-operations/cursor`
+- :doc:`/fundamentals/crud/read-operations/sort`
+- :doc:`/fundamentals/crud/read-operations/skip`
+- :doc:`/fundamentals/crud/read-operations/limit`
+- :doc:`/fundamentals/crud/read-operations/project`
+- :doc:`/fundamentals/crud/read-operations/geo`
+- :doc:`/fundamentals/crud/read-operations/text`
+
 .. toctree::
    :caption: Read Operations
 

--- a/source/fundamentals/crud/write-operations.txt
+++ b/source/fundamentals/crud/write-operations.txt
@@ -4,6 +4,12 @@ Write Operations
 
 .. default-domain:: mongodb
 
+- :doc:`/fundamentals/crud/write-operations/insert`
+- :doc:`/fundamentals/crud/write-operations/delete`
+- :doc:`/fundamentals/crud/write-operations/change-a-document`
+- :doc:`/fundamentals/crud/write-operations/embedded-arrays`
+- :doc:`/fundamentals/crud/write-operations/upsert`
+
 .. toctree::
    :caption: Write Operations
 


### PR DESCRIPTION
JIRA:
https://jira.mongodb.org/browse/DOCSP-11514

Staging:
Start from: https://docs-mongodbcom-staging.corp.mongodb.com/ea1509f/node/docsworker-xlarge/DOCSP-11514-add-links-read-write/fundamentals/crud
Click Read and Write Operation links.