### PR TITLE
DOCSP-11555: fix link to atlas in quickstart

### DIFF
--- a/source/fundamentals/connection.txt
+++ b/source/fundamentals/connection.txt
@@ -28,7 +28,7 @@ Format </reference/connection-string/#standard-connection-string-format>`.
 .. note::
 
    If your deployment is on MongoDB Atlas, follow the
-   :atlas:`Atlas driver connection guide <driver-connection?tck=docs_driver_nodejs>`
+   :atlas:`Atlas driver connection guide </driver-connection?tck=docs_driver_nodejs>`
    to retrieve your connection string.
 
 The next part of the connection string contains your username and password

--- a/source/includes/atlas-search.rst
+++ b/source/includes/atlas-search.rst
@@ -1,6 +1,6 @@
 .. note::
 
-   :atlas:`Atlas Search <atlas-search?tck=docs_driver_nodejs>` makes it easy
+   :atlas:`Atlas Search </atlas-search?tck=docs_driver_nodejs>` makes it easy
    to build fast, relevance-based search capabilities on top of your MongoDB
    data. Try it today on
    `MongoDB Atlas <https://www.mongodb.com/cloud/atlas?tck=docs_driver_nodejs>`__,

--- a/source/quick-start.txt
+++ b/source/quick-start.txt
@@ -98,7 +98,7 @@ Set up a Free Tier Cluster in Atlas
 
 After installing the Node MongoDB driver, create a MongoDB instance to store
 and manage your data. Complete the
-:atlas:`Get Started with Atlas <getting-started?tck=docs_driver_nodejs>` guide
+:atlas:`Get Started with Atlas </getting-started?tck=docs_driver_nodejs>` guide
 to set up a new Atlas account, free tier cluster (MongoDB instance), load
 datasets, and interact with the data.
 

--- a/source/usage-examples.txt
+++ b/source/usage-examples.txt
@@ -35,10 +35,10 @@ How to Use the Usage Examples
 -----------------------------
 
 These examples use the
-:atlas:`MongoDB Atlas sample data <sample-data?tck=docs_driver_nodejs>`
+:atlas:`MongoDB Atlas sample data </sample-data?tck=docs_driver_nodejs>`
 database. You can use this sample data on the free tier
 of MongoDB Atlas by following the :atlas:`Get Started with Atlas
-<getting-started/#atlas-getting-started?tck=docs_driver_nodejs>` guide or you
+</getting-started/#atlas-getting-started?tck=docs_driver_nodejs>` guide or you
 can :guides:`import the sample dataset into a local MongoDB instance
 </server/import>`.
 


### PR DESCRIPTION
JIRA:
https://jira.mongodb.org/browse/DOCSP-11555

Staging:
https://docs-mongodborg-staging.corp.mongodb.com/42514a6/node/docsworker-xlarge/DOCSP-11555-fix-atlas-link/quick-start

https://docs-mongodborg-staging.corp.mongodb.com/42514a6/node/docsworker-xlarge/DOCSP-11555-fix-atlas-link/fundamentals/connection

https://docs-mongodborg-staging.corp.mongodb.com/42514a6/node/docsworker-xlarge/DOCSP-11555-fix-atlas-link/usage-examples

https://docs-mongodborg-staging.corp.mongodb.com/42514a6/node/docsworker-xlarge/DOCSP-11555-fix-atlas-link/fundamentals/crud/read-operations/text

Caused by change to rstspec.toml `:atlas:` directive