### PR TITLE
DOCSP-11718: add ToC to fundamentals non-landing page

### DIFF
--- a/source/fundamentals.txt
+++ b/source/fundamentals.txt
@@ -4,6 +4,15 @@ Fundamentals
 
 .. default-domain:: mongodb
 
+- :doc:`Connection Guide </fundamentals/connection>`
+- :doc:`Authentication </fundamentals/authentication>`
+- :doc:`CRUD Operations </fundamentals/crud>`
+- :doc:`Promises and Callbacks </fundamentals/promises>`
+- :doc:`Indexes </fundamentals/indexes>`
+- :doc:`Collations </fundamentals/collations>`
+- :doc:`Logging </fundamentals/logging>`
+- :doc:`Monitoring </fundamentals/monitoring>`
+
 .. toctree::
 
    /fundamentals/connection

--- a/source/usage-examples/delete-operations.txt
+++ b/source/usage-examples/delete-operations.txt
@@ -13,3 +13,4 @@ Delete Operations
 
    /usage-examples/deleteOne
    /usage-examples/deleteMany
+


### PR DESCRIPTION
JIRA:
https://jira.mongodb.org/browse/DOCSP-11718

Staging:
https://docs-mongodborg-staging.corp.mongodb.com/aebf623/node/docsworker-xlarge/DOCSP-11718-add-toc/fundamentals

Checked all other non-landing drawer pages and they all contained an in-document ToC. Users must be opening new tabs/windows using the nav links to arrive at these pages.
