### PR TITLE
bug: code-snippet invalid function call (ie typo)

### DIFF
--- a/source/code-snippets/indexes/text.js
+++ b/source/code-snippets/indexes/text.js
@@ -26,7 +26,7 @@ async function run() {
     const projection = { fullplot: 1 };
     const cursor = movies
       .find(query)
-      .projection(projection);
+      .project(projection);
     // end-query
 
   } finally {


### PR DESCRIPTION
## 12/29/2020
### Minor TypeError:
`TypeError: movies.find(...).projection is not a function`

Discovered when exploring docs (**$textSearch**): via [doc example](https://docs.mongodb.com/drivers/node/fundamentals/crud/read-operations/text)

Hopefully, this helps avoid some confusion for those learning :)