### PR TITLE
fix syntax of examples on query-document

### DIFF
--- a/source/fundamentals/crud/query-document.txt
+++ b/source/fundamentals/crud/query-document.txt
@@ -146,9 +146,9 @@ This code snippet returns the following results:
   .. code-block:: javascript
 
     collection.find({
-      $and : [
-         rating: { $eq: 5 },
-         qty: { $gt: 4 }
+      $and: [
+         { rating: { $eq: 5 }},
+         { qty: { $gt: 4 }}
       ]
     })
 
@@ -165,7 +165,7 @@ field:
 
 .. code-block:: javascript
 
-   const query = { microsieverts: { $exists : true } };
+   const query = { microsieverts: { $exists: true } };
    const cursor = collection.find(query);
    await cursor.forEach(console.dir);
 


### PR DESCRIPTION
no JIRA

Staging:
https://docs-mongodbcom-staging.corp.mongodb.com/4ecea5a/node/docsworker-xlarge/011421-node-fix/fundamentals/crud/query-document