### PR TITLE
bug: update connectTimeoutMS default value

### DIFF
--- a/source/faq.txt
+++ b/source/faq.txt
@@ -24,7 +24,7 @@ What Is the Difference Between "connectTimeoutMS", "socketTimeoutMS" and "maxTim
    * - connectTimeoutMS
      - | ``connectTimeoutMS`` is a :ref:`connection option <connection-options>` that sets the time in milliseconds for an individual connection from your connection pool to establish a TCP connection to the MongoDB server before timing out. Use the ``serverSelectionTimeoutMS`` option instead to fail when :node-api:`MongoClient.connect <MongoClient.html#.connect>` is unable to establish a connection with the MongoDB server.
        |
-       | **Default:** 30000
+       | **Default:** 10000
    * - socketTimeoutMS
      - ``socketTimeoutMS`` specifies the amount of time the driver waits
        for an inactive socket before closing it. The default value is to

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -22,9 +22,16 @@ What Is the Difference Between "connectTimeoutMS", "socketTimeoutMS" and "maxTim
    * - Setting
      - Description
    * - connectTimeoutMS
-     - | ``connectTimeoutMS`` is a :ref:`connection option <connection-options>` that sets the time in milliseconds for an individual connection from your connection pool to establish a TCP connection to the MongoDB server before timing out. Use the ``serverSelectionTimeoutMS`` option instead to fail when :node-api:`MongoClient.connect <MongoClient.html#.connect>` is unable to establish a connection with the MongoDB server.
-       |
-       | **Default:** 10000
+     - ``connectTimeoutMS`` is a :ref:`connection option <connection-options>` that sets the time, in milliseconds,
+       for an individual connection from your connection pool to establish a TCP connection to the MongoDB server before
+       timing out.
+
+       .. tip::
+
+          To modify the allowed time for :node-api:`MongoClient.connect <MongoClient.html#.connect>` to establish a
+          connection to a MongoDB server, use the ``serverSelectionTimeoutMS`` option instead.
+
+       **Default:** 10000
    * - socketTimeoutMS
      - ``socketTimeoutMS`` specifies the amount of time the driver waits
        for an inactive socket before closing it. The default value is to

--- a/source/fundamentals/connection.txt
+++ b/source/fundamentals/connection.txt
@@ -95,7 +95,7 @@ URI to specify the behavior of the client.
 
    * - **connectTimeoutMS**
      - integer
-     - ``30000``
+     - ``10000``
      - Specifies the number of milliseconds to wait before timeout on a TCP
        connection.
 


### PR DESCRIPTION
## Pull Request Info

The `connectTimeoutMS` default value is 10000 milliseconds, and we had it listed as 30000 millis.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-13986

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/a8fb166/node/docsworker-xlarge/DOCSP-13986/fundamentals/connection#connection-options
https://docs-mongodbcom-staging.corp.mongodb.com/a8fb166/node/docsworker-xlarge/DOCSP-13986/faq

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?
