### PR TITLE
DOCSP-14071: use stream() on cursor for streaming api

### DIFF
--- a/source/code-snippets/crud/cursor.js
+++ b/source/code-snippets/crud/cursor.js
@@ -37,15 +37,7 @@ async function manualIteration(collection) {
 async function streamAPI(collection) {
   // start stream cursor example
   const cursor = collection.find({});
-  cursor.pipe(
-    new stream.Writable({
-      objectMode: true,
-      write: function(doc, _, callback) {
-        console.log(doc);
-        callback();
-      },
-    }),
-  );
+  cursor.stream().on("data", doc => console.log(doc));
   // end stream cursor example
 }
 

--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -100,9 +100,8 @@ method to retrieve the subsequent element of the cursor:
 Stream API
 ~~~~~~~~~~
 
-All cursors are Node Readable Streams that operate in **Object Mode** which
-passes JavaScript objects rather than Buffers or Strings through the
-pipeline. Cursors work with most Node stream APIs:
+Cursors expose the ``stream()`` method to convert them to Node Readable Streams. These streams operate in **Object
+Mode**, which passes JavaScript objects rather than Buffers or Strings through the pipeline.
 
 .. literalinclude:: /code-snippets/crud/cursor.js
    :language: javascript


### PR DESCRIPTION
## Pull Request Info

Per the ticket description in mongodb@4, `stream()` must now be called on the cursor to use the stream API.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-14071

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/faaae47/node/docsworker-xlarge/DOCSP-14071/fundamentals/crud/read-operations/cursor/#stream-api

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?
