### PR TITLE
DOCSP-14304: document directConnection

### DIFF
--- a/source/fundamentals/connection.txt
+++ b/source/fundamentals/connection.txt
@@ -69,6 +69,13 @@ of the ``replicaSet`` parameter in the connection string.
 
    mongodb://host1:27017,host2:27017,host3:27017/?replicaSet=myRs
 
+
+.. note::
+
+   Although it is possible to connect to a replica set deployment by
+   providing only a single host, you should provide the driver with the
+   full list to ensure that it is able to connect in the event the specified host is unavailable.
+
 Direct Connection
 +++++++++++++++++
 
@@ -76,13 +83,6 @@ By default, the driver will discover all members of the replica set given the ad
 and will dispatch operations to the appropriate member, such as writes against the **primary**.
 
 To force operations on the server designated in the connection URI, specify the ``directConnection`` option.
-
-
-.. note::
-
-   Although it is possible to connect to a replica set deployment by
-   providing only a single host, you should provide the driver with the
-   full list to ensure that it is able to connect in the event the specified host is unavailable.
 
 .. _connection-options:
 

--- a/source/fundamentals/connection.txt
+++ b/source/fundamentals/connection.txt
@@ -69,20 +69,26 @@ of the ``replicaSet`` parameter in the connection string.
 
    mongodb://host1:27017,host2:27017,host3:27017/?replicaSet=myRs
 
+When making a connection, the driver takes the following actions by default:
 
-.. note::
+- Discovers all replica set members when given the address of any one member.
+- Dispatches operations to the appropriate member, such as write against the **primary**.
 
-   Although it is possible to connect to a replica set deployment by
-   providing only a single host, you should provide the driver with the
-   full list to ensure that it is able to connect in the event the specified host is unavailable.
+.. tip::
+
+   You only need to specify one host to connect to a replica set. However, to ensure connectivey if the specified host
+   is unavailable, provide the full list of hosts.
 
 Direct Connection
 +++++++++++++++++
 
-By default, the driver will discover all members of the replica set given the address of any one member,
-and will dispatch operations to the appropriate member, such as writes against the **primary**.
+To force operations on the host designated in the connection URI, specify the ``directConnection`` option. Direct
+connections:
 
-To force operations on the server designated in the connection URI, specify the ``directConnection`` option.
+- do not support SRV strings.
+- will error on writes when the specified host is not the **primary**.
+- require :manual:`enabling secondary reads </reference/method/rs.secondaryOk/>` when the specified host in not the
+  **primary**.
 
 .. _connection-options:
 
@@ -242,7 +248,7 @@ URI to specify the behavior of the client.
    * - **directConnection**
      - boolean
      - ``false``
-     - Specifies whether to force dispatch **all** operations to the server
+     - Specifies whether to force dispatch **all** operations to the host
        specified in the connection URI.
 
 

--- a/source/fundamentals/connection.txt
+++ b/source/fundamentals/connection.txt
@@ -76,7 +76,7 @@ When making a connection, the driver takes the following actions by default:
 
 .. tip::
 
-   You only need to specify one host to connect to a replica set. However, to ensure connectivey if the specified host
+   You only need to specify one host to connect to a replica set. However, to ensure connectivity if the specified host
    is unavailable, provide the full list of hosts.
 
 Direct Connection

--- a/source/fundamentals/connection.txt
+++ b/source/fundamentals/connection.txt
@@ -69,11 +69,20 @@ of the ``replicaSet`` parameter in the connection string.
 
    mongodb://host1:27017,host2:27017,host3:27017/?replicaSet=myRs
 
+Direct Connection
++++++++++++++++++
+
+By default, the driver will discover all members of the replica set given the address of any one member,
+and will dispatch operations to the appropriate member, such as writes against the **primary**.
+
+To force operations on the server designated in the connection URI, specify the ``directConnection`` option.
+
+
 .. note::
 
    Although it is possible to connect to a replica set deployment by
    providing only a single host, you should provide the driver with the
-   full list to ensure that it is able to connect even if one host fails.
+   full list to ensure that it is able to connect in the event the specified host is unavailable.
 
 .. _connection-options:
 
@@ -229,6 +238,12 @@ URI to specify the behavior of the client.
      - Specifies the write concern. For more information on values, see the
        server documentation on the
        :manual:`w Option </reference/write-concern/#w-option>`.
+
+   * - **directConnection**
+     - boolean
+     - ``false``
+     - Specifies whether to force dispatch **all** operations to the server
+       specified in the connection URI.
 
 
 

--- a/source/fundamentals/connection.txt
+++ b/source/fundamentals/connection.txt
@@ -85,10 +85,10 @@ Direct Connection
 To force operations on the host designated in the connection URI, specify the ``directConnection`` option. Direct
 connections:
 
-- do not support SRV strings.
-- will error on writes when the specified host is not the **primary**.
-- require :manual:`enabling secondary reads </reference/method/rs.secondaryOk/>` when the specified host in not the
-  **primary**.
+- Don't support SRV strings.
+- Fails on writes when the specified host is not the **primary**.
+- Require :manual:`enabling secondary reads </reference/method/rs.secondaryOk/>`
+   when the specified host isn't the **primary**.
 
 .. _connection-options:
 


### PR DESCRIPTION
## Pull Request Info

This documents the `directConnection` parameter in the options list and explains it in the context of replica sets.

Target is all branches so I will cherry-pick this to v3.6 and push.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-14304

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/d40be7e/node/docsworker-xlarge/DOCSP-14304/fundamentals/connection/#connect-to-a-replica-set

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?
