### PR TITLE
Doscp 14337

### DIFF
--- a/source/fundamentals/authentication/enterprise-mechanisms.txt
+++ b/source/fundamentals/authentication/enterprise-mechanisms.txt
@@ -30,6 +30,9 @@ parameters of the
 
    The ``gssapiServiceName`` parameter, although still supported by the MongoDB Node driver,
    is a *deprecated* alias for ``authMechanismProperties=SERVICE_NAME:<your service name>``.
+   See the
+   :manual:`authMechanismProperties </reference/connection-string/#urioption.authMechanismProperties>`
+   parameter documentation for more information.
 
 The following code sample authenticates to Kerberos for UNIX using ``GSSAPI``.
 

--- a/source/fundamentals/authentication/enterprise-mechanisms.txt
+++ b/source/fundamentals/authentication/enterprise-mechanisms.txt
@@ -21,9 +21,15 @@ parameters of the
 :manual:`connection string </reference/connection-string/>`:
 
 - Set the ``authMechanism`` parameter to ``GSSAPI``
-- Set the ``gssapiServiceName`` if using a value other than ``mongodb``
+- Set the ``SERVICE_NAME`` value in the ``authMechanismProperties``
+  parameter if using a value other than ``mongodb``
 - Specify a ``SERVICE_REALM`` value in the ``authMechanismProperties``
   parameter if a custom service realm is required.
+
+.. note::
+
+   The ``gssapiServiceName`` parameter, although still supported by the MongoDB Node driver,
+   is a *deprecated* alias for ``authMechanismProperties=SERVICE_NAME:<your service name>``.
 
 The following code sample authenticates to Kerberos for UNIX using ``GSSAPI``.
 

--- a/source/fundamentals/authentication/enterprise-mechanisms.txt
+++ b/source/fundamentals/authentication/enterprise-mechanisms.txt
@@ -26,10 +26,12 @@ parameters of the
 - Specify a ``SERVICE_REALM`` value in the ``authMechanismProperties``
   parameter if a custom service realm is required.
 
-.. note::
-
-   The ``gssapiServiceName`` parameter, although still supported by the MongoDB Node driver,
-   is a *deprecated* alias for ``authMechanismProperties=SERVICE_NAME:<your service name>``.
+.. important::
+   
+   The ``gssapiServiceName`` parameter is deprecated and may be removed
+   in future versions of the driver. Use
+   ``authMechanismProperties=SERVICE_NAME:<your service name>`` in the
+   connection URI instead.
    See the
    :manual:`authMechanismProperties </reference/connection-string/#urioption.authMechanismProperties>`
    parameter documentation for more information.


### PR DESCRIPTION
## Pull Request Info
Update Node 4.0 Authentication Parameters to specify that `gssapiServiceName` is deprecated. 

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-14337

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/a43f746/node/docsworker-xlarge/DOSCP-14337/fundamentals/authentication/enterprise-mechanisms/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?
