### PR TITLE
avoid deprecation warnings in 3.6

### DIFF
--- a/source/code-snippets/authentication/aws.js
+++ b/source/code-snippets/authentication/aws.js
@@ -12,7 +12,10 @@ const uri =
   `mongodb+srv://${accessKeyId}:${secretAccessKey}@${clusterUrl}/?authMechanism=${authMechanism}`;
 
 // Create a new MongoClient
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, {
+  useNewUrlParser: true
+  useUnifiedTopology: true,
+});
 
 // Function to connect to the server
 async function run() {

--- a/source/code-snippets/authentication/cr.js
+++ b/source/code-snippets/authentication/cr.js
@@ -10,7 +10,10 @@ const uri =
   `mongodb+srv://${username}:${password}@${clusterUrl}/?authMechanism=${authMechanism}&tls=true&tlsCertificateKeyFile=${clientPEMFile}`;
 
 // Create a new MongoClient
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, {
+  useNewUrlParser: true
+  useUnifiedTopology: true,
+});
 
 // Function to connect to the server
 async function run() {

--- a/source/code-snippets/authentication/default.js
+++ b/source/code-snippets/authentication/default.js
@@ -12,7 +12,10 @@ const uri =
   `mongodb+srv://${username}:${password}@${clusterUrl}/?authMechanism=${authMechanism}`;
 
 // Create a new MongoClient
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, {
+  useNewUrlParser: true
+  useUnifiedTopology: true,
+});
 
 // Function to connect to the server
 async function run() {

--- a/source/code-snippets/authentication/sha1.js
+++ b/source/code-snippets/authentication/sha1.js
@@ -12,7 +12,10 @@ const uri =
   `mongodb+srv://${username}:${password}@${clusterUrl}/?authMechanism=${authMechanism}`;
 
 // Create a new MongoClient
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, {
+  useNewUrlParser: true
+  useUnifiedTopology: true,
+});
 
 // Function to connect to the server
 async function run() {

--- a/source/code-snippets/authentication/sha256.js
+++ b/source/code-snippets/authentication/sha256.js
@@ -12,7 +12,10 @@ const uri =
   `mongodb+srv://${username}:${password}@${clusterUrl}/?authMechanism=${authMechanism}`;
 
 // Create a new MongoClient
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, {
+  useNewUrlParser: true
+  useUnifiedTopology: true,
+});
 
 // Function to connect to the server
 async function run() {

--- a/source/code-snippets/authentication/x509.js
+++ b/source/code-snippets/authentication/x509.js
@@ -12,7 +12,10 @@ const uri =
   `mongodb+srv://${username}@${clusterUrl}/?authMechanism=${authMechanism}&tls=true&tlsCertificateKeyFile=${clientPEMFile}`;
 
 // Create a new MongoClient
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, {
+  useNewUrlParser: true
+  useUnifiedTopology: true,
+});
 
 // Function to connect to the server
 async function run() {

--- a/source/code-snippets/connection/srv.js
+++ b/source/code-snippets/connection/srv.js
@@ -5,7 +5,10 @@ const uri =
   "mongodb+srv://sample-hostname:27017/?poolSize=20&writeConcern=majority";
 
 // Create a new MongoClient
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, {
+  useNewUrlParser: true
+  useUnifiedTopology: true,
+});
 
 async function run() {
   try {

--- a/source/code-snippets/crud/arrayFilters.js
+++ b/source/code-snippets/crud/arrayFilters.js
@@ -4,7 +4,10 @@ const stream = require("stream");
 // Replace the following string with your MongoDB deployment's connection string.
 const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, {
+  useNewUrlParser: true
+  useUnifiedTopology: true,
+});
 
 
 async function loadData() {

--- a/source/code-snippets/crud/cursor.js
+++ b/source/code-snippets/crud/cursor.js
@@ -4,7 +4,10 @@ const stream = require("stream");
 // Replace the following string with your MongoDB deployment's connection string.
 const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, {
+  useNewUrlParser: true
+  useUnifiedTopology: true,
+});
 
 async function forEachIteration(collection) {
   // start foreach cursor example

--- a/source/code-snippets/crud/pizza.js
+++ b/source/code-snippets/crud/pizza.js
@@ -3,7 +3,10 @@ const { MongoClient } = require("mongodb");
 // Replace the following string with your MongoDB deployment's connection string.
 const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, {
+  useNewUrlParser: true
+  useUnifiedTopology: true,
+});
 
 function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));

--- a/source/code-snippets/crud/startrek.js
+++ b/source/code-snippets/crud/startrek.js
@@ -3,7 +3,10 @@ const { MongoClient } = require("mongodb");
 // Replace the following string with your MongoDB deployment's connection string.
 const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, {
+  useNewUrlParser: true
+  useUnifiedTopology: true,
+});
 
 async function word(movies) {
   // start word text example

--- a/source/code-snippets/crud/theaters.js
+++ b/source/code-snippets/crud/theaters.js
@@ -3,7 +3,10 @@ const { MongoClient } = require("mongodb");
 // Replace the following string with your MongoDB deployment's connection string.
 const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, {
+  useNewUrlParser: true
+  useUnifiedTopology: true,
+});
 
 async function proximity(theaters) {
   // start proximity geo example

--- a/source/code-snippets/faq/econnresetWithClientConnect-example.js
+++ b/source/code-snippets/faq/econnresetWithClientConnect-example.js
@@ -1,6 +1,9 @@
 const uri = "mongodb://localhost:27017/test?maxPoolSize=5000";
 // create a new MongoClient
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, {
+  useNewUrlParser: true
+  useUnifiedTopology: true,
+});
 
 await client.connect(err => {
   // connection

--- a/source/code-snippets/indexes/compound.js
+++ b/source/code-snippets/indexes/compound.js
@@ -5,7 +5,10 @@ const { MongoClient } = require("mongodb");
 const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, {
+  useNewUrlParser: true
+  useUnifiedTopology: true,
+});
 
 async function run() {
   try {

--- a/source/code-snippets/indexes/geo.js
+++ b/source/code-snippets/indexes/geo.js
@@ -5,7 +5,10 @@ const { MongoClient } = require("mongodb");
 const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, {
+  useNewUrlParser: true
+  useUnifiedTopology: true,
+});
 
 async function run() {
   try {

--- a/source/code-snippets/indexes/multikey.js
+++ b/source/code-snippets/indexes/multikey.js
@@ -5,7 +5,10 @@ const { MongoClient } = require("mongodb");
 const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, {
+  useNewUrlParser: true
+  useUnifiedTopology: true,
+});
 
 async function run() {
   try {

--- a/source/code-snippets/indexes/single-field.js
+++ b/source/code-snippets/indexes/single-field.js
@@ -5,7 +5,10 @@ const { MongoClient } = require("mongodb");
 const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, {
+  useNewUrlParser: true
+  useUnifiedTopology: true,
+});
 
 async function run() {
   try {

--- a/source/code-snippets/indexes/text.js
+++ b/source/code-snippets/indexes/text.js
@@ -5,7 +5,10 @@ const { MongoClient } = require("mongodb");
 const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, {
+  useNewUrlParser: true
+  useUnifiedTopology: true,
+});
 
 async function run() {
   try {

--- a/source/code-snippets/indexes/unique.js
+++ b/source/code-snippets/indexes/unique.js
@@ -5,7 +5,10 @@ const { MongoClient } = require("mongodb");
 const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, {
+  useNewUrlParser: true
+  useUnifiedTopology: true,
+});
 
 async function run() {
   try {

--- a/source/code-snippets/logging/levels.js
+++ b/source/code-snippets/logging/levels.js
@@ -5,7 +5,10 @@ const { MongoClient, Logger } = require("mongodb");
 const uri =
   "mongodb+srv://<clusterUrl>/?replicaSet=rs&writeConcern=majority";
 
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, {
+  useNewUrlParser: true
+  useUnifiedTopology: true,
+});
 
 async function main(client) {
   // Set debug level

--- a/source/code-snippets/monitoring/subscribe.js
+++ b/source/code-snippets/monitoring/subscribe.js
@@ -5,7 +5,10 @@ const { MongoClient } = require("mongodb");
 const uri =
   "mongodb+srv://<clusterUrl>/?replicaSet=rs&writeConcern=majority";
 
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, {
+  useNewUrlParser: true
+  useUnifiedTopology: true,
+});
 
 // Replace <event name> with the name of the event you are subscribing to.
 const eventName = "<event name>";

--- a/source/code-snippets/usage-examples/bulkWrite.js
+++ b/source/code-snippets/usage-examples/bulkWrite.js
@@ -4,7 +4,10 @@ const { MongoClient } = require("mongodb");
 const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, {
+  useNewUrlParser: true
+  useUnifiedTopology: true,
+});
 
 async function run() {
   try {

--- a/source/code-snippets/usage-examples/changeStream.js
+++ b/source/code-snippets/usage-examples/changeStream.js
@@ -4,7 +4,10 @@ const { MongoClient } = require("mongodb");
 const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, {
+  useNewUrlParser: true
+  useUnifiedTopology: true,
+});
 
 let changeStream;
 async function run() {

--- a/source/code-snippets/usage-examples/command.js
+++ b/source/code-snippets/usage-examples/command.js
@@ -4,7 +4,10 @@ const { MongoClient } = require("mongodb");
 const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, {
+  useNewUrlParser: true
+  useUnifiedTopology: true,
+});
 
 async function run() {
   try {

--- a/source/code-snippets/usage-examples/count.js
+++ b/source/code-snippets/usage-examples/count.js
@@ -4,7 +4,10 @@ const { MongoClient } = require("mongodb");
 const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, {
+  useNewUrlParser: true
+  useUnifiedTopology: true,
+});
 
 async function run() {
   try {

--- a/source/code-snippets/usage-examples/deleteMany.js
+++ b/source/code-snippets/usage-examples/deleteMany.js
@@ -4,7 +4,10 @@ const { MongoClient } = require("mongodb");
 const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, {
+  useNewUrlParser: true
+  useUnifiedTopology: true,
+});
 
 async function run() {
   try {

--- a/source/code-snippets/usage-examples/deleteOne.js
+++ b/source/code-snippets/usage-examples/deleteOne.js
@@ -4,7 +4,10 @@ const { MongoClient } = require("mongodb");
 const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, {
+  useNewUrlParser: true
+  useUnifiedTopology: true,
+});
 
 async function run() {
   try {

--- a/source/code-snippets/usage-examples/distinct.js
+++ b/source/code-snippets/usage-examples/distinct.js
@@ -4,7 +4,10 @@ const { MongoClient } = require("mongodb");
 const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, {
+  useNewUrlParser: true
+  useUnifiedTopology: true,
+});
 
 async function run() {
   try {

--- a/source/code-snippets/usage-examples/find.js
+++ b/source/code-snippets/usage-examples/find.js
@@ -4,7 +4,10 @@ const { MongoClient } = require("mongodb");
 const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, {
+  useNewUrlParser: true
+  useUnifiedTopology: true,
+});
 
 async function run() {
   try {

--- a/source/code-snippets/usage-examples/findOne.js
+++ b/source/code-snippets/usage-examples/findOne.js
@@ -4,7 +4,10 @@ const { MongoClient } = require("mongodb");
 const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, {
+  useNewUrlParser: true
+  useUnifiedTopology: true,
+});
 
 async function run() {
   try {

--- a/source/code-snippets/usage-examples/insertMany.js
+++ b/source/code-snippets/usage-examples/insertMany.js
@@ -4,7 +4,10 @@ const { MongoClient } = require("mongodb");
 const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, {
+  useNewUrlParser: true
+  useUnifiedTopology: true,
+});
 
 async function run() {
   try {

--- a/source/code-snippets/usage-examples/insertOne.js
+++ b/source/code-snippets/usage-examples/insertOne.js
@@ -4,7 +4,10 @@ const { MongoClient } = require("mongodb");
 const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, {
+  useNewUrlParser: true
+  useUnifiedTopology: true,
+});
 
 async function run() {
   try {

--- a/source/code-snippets/usage-examples/replaceOne.js
+++ b/source/code-snippets/usage-examples/replaceOne.js
@@ -4,7 +4,10 @@ const { MongoClient } = require("mongodb");
 const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, {
+  useNewUrlParser: true
+  useUnifiedTopology: true,
+});
 
 async function run() {
   try {

--- a/source/code-snippets/usage-examples/updateMany.js
+++ b/source/code-snippets/usage-examples/updateMany.js
@@ -4,7 +4,10 @@ const { MongoClient } = require("mongodb");
 const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, {
+  useNewUrlParser: true
+  useUnifiedTopology: true,
+});
 
 async function run() {
   try {

--- a/source/code-snippets/usage-examples/updateOne.js
+++ b/source/code-snippets/usage-examples/updateOne.js
@@ -4,7 +4,10 @@ const { MongoClient } = require("mongodb");
 const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, {
+  useNewUrlParser: true
+  useUnifiedTopology: true,
+});
 
 async function run() {
   try {

--- a/source/fundamentals/authentication/enterprise-mechanisms.txt
+++ b/source/fundamentals/authentication/enterprise-mechanisms.txt
@@ -46,7 +46,10 @@ The following code sample authenticates to Kerberos for UNIX using ``GSSAPI``.
    // Connection URI
    const uri = `mongodb+srv://${principal}@${clusterUrl}/?authMechanism=${authMechanism}&authMechanismProperties=${authMechanismProperties}`;
 
-   const client = new MongoClient(uri);
+   const client = new MongoClient(uri, {
+     useNewUrlParser: true,
+     useUnifiedTopology: true,
+   });
 
    // Function to connect to the server
    async function run() {
@@ -94,7 +97,10 @@ in the following sample code.
    // Connection URI
    const uri = `mongodb+srv://${ldapUsername}:${ldapPassword}@${clusterUrl}/?authMechanism=${authMechanism}`;
 
-   const client = new MongoClient(uri);
+   const client = new MongoClient(uri, {
+     useNewUrlParser: true,
+     useUnifiedTopology: true,
+   });
 
    // Function to connect to the server
    async function run() {

--- a/source/quick-start.txt
+++ b/source/quick-start.txt
@@ -151,7 +151,10 @@ that has **atlasAdmin** permissions.
   const uri =
     "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&writeConcern=majority";
 
-  const client = new MongoClient(uri);
+  const client = new MongoClient(uri, {
+    useNewUrlParser: true
+    useUnifiedTopology: true,
+  });
 
   async function run() {
     try {


### PR DESCRIPTION
## Pull Request Info
This adds the options for `useNewUrlParser` and `useUnifiedTopology` to avoid deprecation warnings upon MongoClient creation with the 3.6 version of the driver.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCS-14176

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/245c85b/node/docsworker-xlarge/DOCS-14176/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?
