### PR TITLE
remove note from upcoming/master about driver version

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -28,16 +28,6 @@ connect to MongoDB and work with data. The driver features an asynchronous
 API which allows you to access method return values through Promises or
 specify callbacks to access them when communicating with MongoDB.
 
-.. note::
-
-   These docs are for version 3.6 of the MongoDB Node.js driver. If
-   you are looking for an older version of the MongoDB Node.js driver
-   docs, `see the legacy Node.js driver documentation
-   <http://mongodb.github.io/node-mongodb-native/>`_.
-   For the main MongoDB documentation, see the :manual:`MongoDB Manual
-   </>`.
-
-
 Take the free online course taught by MongoDB
 ---------------------------------------------
 


### PR DESCRIPTION
## Pull Request Info

This PR removes the note from the master branch that these docs are for the 3.6 version of the driver and where to find docs for older versions.

### Issue JIRA link:
N/A

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/212f2bd/node/docsworker-xlarge/remove-note/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?
