### PR TITLE
DOCSP-15136: fix text in fundamentals limit page

### DIFF
--- a/source/fundamentals/crud/read-operations/limit.txt
+++ b/source/fundamentals/crud/read-operations/limit.txt
@@ -83,7 +83,7 @@ the number of documents to skim over to the previous code snippet's call to
 ``find()``:
 
 .. code-block:: javascript
-   :emphasize-lines: 6
+   :emphasize-lines: 6,7
 
    // define an empty query document
    const query = {};

--- a/source/fundamentals/crud/read-operations/limit.txt
+++ b/source/fundamentals/crud/read-operations/limit.txt
@@ -78,9 +78,8 @@ For more information on the ``options`` settings for the ``find()``
 method, see the
 :node-api:`API documentation on find() <Collection.html#find>`.
 
-To see the next three shortest books, append the ``skip()`` method, passing
-the number of documents to skim over to the previous code snippet's call to
-``find()``:
+To see the next three books in the results, append the ``skip()`` method,
+passing the number of documents to skim over as shown below:
 
 .. code-block:: javascript
    :emphasize-lines: 6,7
@@ -95,7 +94,7 @@ the number of documents to skim over to the previous code snippet's call to
    await cursor.forEach(console.dir);
 
 This operation returns the documents that describe the fourth through sixth
-longest books:
+books in order of longest-to-shortest length:
 
 .. code-block:: javascript
 

--- a/source/fundamentals/crud/read-operations/limit.txt
+++ b/source/fundamentals/crud/read-operations/limit.txt
@@ -78,17 +78,17 @@ For more information on the ``options`` settings for the ``find()``
 method, see the
 :node-api:`API documentation on find() <Collection.html#find>`.
 
-To see the next three longest books, append the ``skip()`` method, passing
+To see the next three shortest books, append the ``skip()`` method, passing
 the number of documents to skim over to the previous code snippet's call to
 ``find()``:
 
 .. code-block:: javascript
-   :emphasize-lines: 4
+   :emphasize-lines: 6
 
    // define an empty query document
    const query = {};
-   // sort in ascending (1) order by length
-   const sort = { length: 1 };
+   // sort in descending (-1) order by length
+   const sort = { length: -1 };
    const limit = 3;
    const skip = 3;
    const cursor = collection.find(query).sort(sort).limit(limit).skip(skip);

--- a/source/fundamentals/crud/read-operations/limit.txt
+++ b/source/fundamentals/crud/read-operations/limit.txt
@@ -79,7 +79,7 @@ method, see the
 :node-api:`API documentation on find() <Collection.html#find>`.
 
 To see the next three books in the results, append the ``skip()`` method,
-passing the number of documents to skim over as shown below:
+passing the number of documents to bypass as shown below:
 
 .. code-block:: javascript
    :emphasize-lines: 6,7


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-15136

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/87c8d69/node/docsworker-xlarge/DOCSP-15136-fix-limit/fundamentals/crud/read-operations/limit/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?
