### PR TITLE
DOCSP-15136: fix text in fundamentals limit page (#152)

### DIFF
--- a/source/fundamentals/crud/read-operations/limit.txt
+++ b/source/fundamentals/crud/read-operations/limit.txt
@@ -78,24 +78,23 @@ For more information on the ``options`` settings for the ``find()``
 method, see the
 :node-api:`API documentation on find() <Collection.html#find>`.
 
-To see the next three longest books, append the ``skip()`` method, passing
-the number of documents to skim over to the previous code snippet's call to
-``find()``:
+To see the next three books in the results, append the ``skip()`` method,
+passing the number of documents to bypass as shown below:
 
 .. code-block:: javascript
-   :emphasize-lines: 4
+   :emphasize-lines: 6,7
 
    // define an empty query document
    const query = {};
-   // sort in ascending (1) order by length
-   const sort = { length: 1 };
+   // sort in descending (-1) order by length
+   const sort = { length: -1 };
    const limit = 3;
    const skip = 3;
    const cursor = collection.find(query).sort(sort).limit(limit).skip(skip);
    await cursor.forEach(console.dir);
 
 This operation returns the documents that describe the fourth through sixth
-longest books:
+books in order of longest-to-shortest length:
 
 .. code-block:: javascript
 


### PR DESCRIPTION
* DOCSP-15136: fix text in fundamentals limit page

(cherry picked from commit 231dbf96d1640a5eea63908bfc00efc9d6509d29)

## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-15136

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodborg-staging.corp.mongodb.com/NNNNNNN/node/docsworker-xlarge/NNNNNNNNNNN/

### Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Does it render on staging correctly?
- [ ] Are all the links working?
- [ ] Are the staging links in the PR description updated?
