### PR TITLE
adds missing comma in object literal options argument

### DIFF
--- a/source/code-snippets/authentication/aws.js
+++ b/source/code-snippets/authentication/aws.js
@@ -13,7 +13,7 @@ const uri =
 
 // Create a new MongoClient
 const client = new MongoClient(uri, {
-  useNewUrlParser: true
+  userNewUrlParser: true,
   useUnifiedTopology: true,
 });
 

--- a/source/code-snippets/authentication/cr.js
+++ b/source/code-snippets/authentication/cr.js
@@ -11,7 +11,7 @@ const uri =
 
 // Create a new MongoClient
 const client = new MongoClient(uri, {
-  useNewUrlParser: true
+  userNewUrlParser: true,
   useUnifiedTopology: true,
 });
 

--- a/source/code-snippets/authentication/default.js
+++ b/source/code-snippets/authentication/default.js
@@ -13,7 +13,7 @@ const uri =
 
 // Create a new MongoClient
 const client = new MongoClient(uri, {
-  useNewUrlParser: true
+  userNewUrlParser: true,
   useUnifiedTopology: true,
 });
 

--- a/source/code-snippets/authentication/sha1.js
+++ b/source/code-snippets/authentication/sha1.js
@@ -13,7 +13,7 @@ const uri =
 
 // Create a new MongoClient
 const client = new MongoClient(uri, {
-  useNewUrlParser: true
+  userNewUrlParser: true,
   useUnifiedTopology: true,
 });
 

--- a/source/code-snippets/authentication/sha256.js
+++ b/source/code-snippets/authentication/sha256.js
@@ -13,7 +13,7 @@ const uri =
 
 // Create a new MongoClient
 const client = new MongoClient(uri, {
-  useNewUrlParser: true
+  userNewUrlParser: true,
   useUnifiedTopology: true,
 });
 

--- a/source/code-snippets/authentication/x509.js
+++ b/source/code-snippets/authentication/x509.js
@@ -13,7 +13,7 @@ const uri =
 
 // Create a new MongoClient
 const client = new MongoClient(uri, {
-  useNewUrlParser: true
+  userNewUrlParser: true,
   useUnifiedTopology: true,
 });
 

--- a/source/code-snippets/connection/srv.js
+++ b/source/code-snippets/connection/srv.js
@@ -6,7 +6,7 @@ const uri =
 
 // Create a new MongoClient
 const client = new MongoClient(uri, {
-  useNewUrlParser: true
+  userNewUrlParser: true,
   useUnifiedTopology: true,
 });
 

--- a/source/code-snippets/crud/arrayFilters.js
+++ b/source/code-snippets/crud/arrayFilters.js
@@ -5,7 +5,7 @@ const stream = require("stream");
 const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 const client = new MongoClient(uri, {
-  useNewUrlParser: true
+  userNewUrlParser: true,
   useUnifiedTopology: true,
 });
 

--- a/source/code-snippets/crud/cursor.js
+++ b/source/code-snippets/crud/cursor.js
@@ -5,7 +5,7 @@ const stream = require("stream");
 const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 const client = new MongoClient(uri, {
-  useNewUrlParser: true
+  userNewUrlParser: true,
   useUnifiedTopology: true,
 });
 

--- a/source/code-snippets/crud/pizza.js
+++ b/source/code-snippets/crud/pizza.js
@@ -4,7 +4,7 @@ const { MongoClient } = require("mongodb");
 const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 const client = new MongoClient(uri, {
-  useNewUrlParser: true
+  userNewUrlParser: true,
   useUnifiedTopology: true,
 });
 

--- a/source/code-snippets/crud/startrek.js
+++ b/source/code-snippets/crud/startrek.js
@@ -4,7 +4,7 @@ const { MongoClient } = require("mongodb");
 const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 const client = new MongoClient(uri, {
-  useNewUrlParser: true
+  userNewUrlParser: true,
   useUnifiedTopology: true,
 });
 

--- a/source/code-snippets/crud/theaters.js
+++ b/source/code-snippets/crud/theaters.js
@@ -4,7 +4,7 @@ const { MongoClient } = require("mongodb");
 const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 const client = new MongoClient(uri, {
-  useNewUrlParser: true
+  userNewUrlParser: true,
   useUnifiedTopology: true,
 });
 

--- a/source/code-snippets/faq/econnresetWithClientConnect-example.js
+++ b/source/code-snippets/faq/econnresetWithClientConnect-example.js
@@ -1,7 +1,7 @@
 const uri = "mongodb://localhost:27017/test?maxPoolSize=5000";
 // create a new MongoClient
 const client = new MongoClient(uri, {
-  useNewUrlParser: true
+  userNewUrlParser: true,
   useUnifiedTopology: true,
 });
 

--- a/source/code-snippets/indexes/compound.js
+++ b/source/code-snippets/indexes/compound.js
@@ -6,7 +6,7 @@ const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
 const client = new MongoClient(uri, {
-  useNewUrlParser: true
+  userNewUrlParser: true,
   useUnifiedTopology: true,
 });
 

--- a/source/code-snippets/indexes/geo.js
+++ b/source/code-snippets/indexes/geo.js
@@ -6,7 +6,7 @@ const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
 const client = new MongoClient(uri, {
-  useNewUrlParser: true
+  userNewUrlParser: true,
   useUnifiedTopology: true,
 });
 

--- a/source/code-snippets/indexes/multikey.js
+++ b/source/code-snippets/indexes/multikey.js
@@ -6,7 +6,7 @@ const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
 const client = new MongoClient(uri, {
-  useNewUrlParser: true
+  userNewUrlParser: true,
   useUnifiedTopology: true,
 });
 

--- a/source/code-snippets/indexes/single-field.js
+++ b/source/code-snippets/indexes/single-field.js
@@ -6,7 +6,7 @@ const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
 const client = new MongoClient(uri, {
-  useNewUrlParser: true
+  userNewUrlParser: true,
   useUnifiedTopology: true,
 });
 

--- a/source/code-snippets/indexes/text.js
+++ b/source/code-snippets/indexes/text.js
@@ -6,7 +6,7 @@ const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
 const client = new MongoClient(uri, {
-  useNewUrlParser: true
+  userNewUrlParser: true,
   useUnifiedTopology: true,
 });
 

--- a/source/code-snippets/indexes/unique.js
+++ b/source/code-snippets/indexes/unique.js
@@ -6,7 +6,7 @@ const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
 const client = new MongoClient(uri, {
-  useNewUrlParser: true
+  userNewUrlParser: true,
   useUnifiedTopology: true,
 });
 

--- a/source/code-snippets/logging/levels.js
+++ b/source/code-snippets/logging/levels.js
@@ -6,7 +6,7 @@ const uri =
   "mongodb+srv://<clusterUrl>/?replicaSet=rs&writeConcern=majority";
 
 const client = new MongoClient(uri, {
-  useNewUrlParser: true
+  userNewUrlParser: true,
   useUnifiedTopology: true,
 });
 

--- a/source/code-snippets/monitoring/subscribe.js
+++ b/source/code-snippets/monitoring/subscribe.js
@@ -6,7 +6,7 @@ const uri =
   "mongodb+srv://<clusterUrl>/?replicaSet=rs&writeConcern=majority";
 
 const client = new MongoClient(uri, {
-  useNewUrlParser: true
+  userNewUrlParser: true,
   useUnifiedTopology: true,
 });
 

--- a/source/code-snippets/usage-examples/bulkWrite.js
+++ b/source/code-snippets/usage-examples/bulkWrite.js
@@ -5,7 +5,7 @@ const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
 const client = new MongoClient(uri, {
-  useNewUrlParser: true
+  userNewUrlParser: true,
   useUnifiedTopology: true,
 });
 

--- a/source/code-snippets/usage-examples/changeStream.js
+++ b/source/code-snippets/usage-examples/changeStream.js
@@ -5,7 +5,7 @@ const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
 const client = new MongoClient(uri, {
-  useNewUrlParser: true
+  userNewUrlParser: true,
   useUnifiedTopology: true,
 });
 

--- a/source/code-snippets/usage-examples/command.js
+++ b/source/code-snippets/usage-examples/command.js
@@ -5,7 +5,7 @@ const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
 const client = new MongoClient(uri, {
-  useNewUrlParser: true
+  userNewUrlParser: true,
   useUnifiedTopology: true,
 });
 

--- a/source/code-snippets/usage-examples/count.js
+++ b/source/code-snippets/usage-examples/count.js
@@ -5,7 +5,7 @@ const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
 const client = new MongoClient(uri, {
-  useNewUrlParser: true
+  userNewUrlParser: true,
   useUnifiedTopology: true,
 });
 

--- a/source/code-snippets/usage-examples/deleteMany.js
+++ b/source/code-snippets/usage-examples/deleteMany.js
@@ -5,7 +5,7 @@ const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
 const client = new MongoClient(uri, {
-  useNewUrlParser: true
+  userNewUrlParser: true,
   useUnifiedTopology: true,
 });
 

--- a/source/code-snippets/usage-examples/deleteOne.js
+++ b/source/code-snippets/usage-examples/deleteOne.js
@@ -5,7 +5,7 @@ const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
 const client = new MongoClient(uri, {
-  useNewUrlParser: true
+  userNewUrlParser: true,
   useUnifiedTopology: true,
 });
 

--- a/source/code-snippets/usage-examples/distinct.js
+++ b/source/code-snippets/usage-examples/distinct.js
@@ -5,7 +5,7 @@ const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
 const client = new MongoClient(uri, {
-  useNewUrlParser: true
+  userNewUrlParser: true,
   useUnifiedTopology: true,
 });
 

--- a/source/code-snippets/usage-examples/find.js
+++ b/source/code-snippets/usage-examples/find.js
@@ -5,7 +5,7 @@ const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
 const client = new MongoClient(uri, {
-  useNewUrlParser: true
+  userNewUrlParser: true,
   useUnifiedTopology: true,
 });
 

--- a/source/code-snippets/usage-examples/findOne.js
+++ b/source/code-snippets/usage-examples/findOne.js
@@ -5,7 +5,7 @@ const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
 const client = new MongoClient(uri, {
-  useNewUrlParser: true
+  userNewUrlParser: true,
   useUnifiedTopology: true,
 });
 

--- a/source/code-snippets/usage-examples/insertMany.js
+++ b/source/code-snippets/usage-examples/insertMany.js
@@ -5,7 +5,7 @@ const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
 const client = new MongoClient(uri, {
-  useNewUrlParser: true
+  userNewUrlParser: true,
   useUnifiedTopology: true,
 });
 

--- a/source/code-snippets/usage-examples/insertOne.js
+++ b/source/code-snippets/usage-examples/insertOne.js
@@ -5,7 +5,7 @@ const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
 const client = new MongoClient(uri, {
-  useNewUrlParser: true
+  userNewUrlParser: true,
   useUnifiedTopology: true,
 });
 

--- a/source/code-snippets/usage-examples/replaceOne.js
+++ b/source/code-snippets/usage-examples/replaceOne.js
@@ -5,7 +5,7 @@ const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
 const client = new MongoClient(uri, {
-  useNewUrlParser: true
+  userNewUrlParser: true,
   useUnifiedTopology: true,
 });
 

--- a/source/code-snippets/usage-examples/updateMany.js
+++ b/source/code-snippets/usage-examples/updateMany.js
@@ -5,7 +5,7 @@ const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
 const client = new MongoClient(uri, {
-  useNewUrlParser: true
+  userNewUrlParser: true,
   useUnifiedTopology: true,
 });
 

--- a/source/code-snippets/usage-examples/updateOne.js
+++ b/source/code-snippets/usage-examples/updateOne.js
@@ -5,7 +5,7 @@ const uri =
   "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
 
 const client = new MongoClient(uri, {
-  useNewUrlParser: true
+  userNewUrlParser: true,
   useUnifiedTopology: true,
 });
 

--- a/source/quick-start.txt
+++ b/source/quick-start.txt
@@ -152,7 +152,7 @@ that has **atlasAdmin** permissions.
     "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&writeConcern=majority";
 
   const client = new MongoClient(uri, {
-    useNewUrlParser: true
+    userNewUrlParser: true,
     useUnifiedTopology: true,
   });
 


### PR DESCRIPTION
## Pull Request Info

This corrects a user reported issue where a comma was missing in an object literal between entries. Targets the v3.6 branch only.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-15228

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/edf8bf7/node/docsworker-xlarge/DOCSP-15528/fundamentals/authentication/mechanisms/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?
