### PR TITLE
DOCSP-15299: add a link to Atlas Sample Data guide

### DIFF
--- a/source/quick-start.txt
+++ b/source/quick-start.txt
@@ -54,20 +54,20 @@ project's files:
 
 .. code-block:: none
 
-  cd node_quickstart
+   cd node_quickstart
 
 Next, set up NPM for your project by running the following command.
 This command creates a file called ``package.json``:
 
 .. code-block:: none
 
-  npm init -y
+   npm init -y
 
 .. note:: Why the -y?
 
-  If you specify the ``-y`` option in the command, NPM automatically
-  accepts the default values for the command. Omit the ``-y`` flag to
-  interactively select your project settings.
+   If you specify the ``-y`` option in the command, NPM automatically
+   accepts the default values for the command. Omit the ``-y`` flag to
+   interactively select your project settings.
 
 Add MongoDB as a Dependency
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -78,7 +78,7 @@ Use the following command to instruct NPM to download and install the
 
 .. code-block:: none
 
-  npm install mongodb
+   npm install mongodb
 
 This command downloads ``mongodb`` package and dependencies required for its
 installation and saves them into a directory called ``node_modules`` in
@@ -98,10 +98,11 @@ Set up a Free Tier Cluster in Atlas
 After installing the Node MongoDB driver, create a MongoDB instance to store
 and manage your data. Complete the
 :atlas:`Get Started with Atlas </getting-started?tck=docs_driver_nodejs>` guide
-to set up a new Atlas account, free tier cluster (MongoDB instance), load
-datasets, and interact with the data.
+to set up a new Atlas account and a free tier cluster (MongoDB instance).
+Then, complete the :atlas:`Load Sample Data into Your Atlas Cluster </sample-data/?tck=docs_driver_nodejs>`
+guide to insert sample data into your cluster.
 
-After completing the steps in the Atlas guide, you should have a new MongoDB
+After completing the steps these Atlas guides, you should have a new MongoDB
 cluster deployed in Atlas, a new database user, and sample datasets loaded
 into your cluster.
 
@@ -176,7 +177,7 @@ Run the sample code with the following command from your command line:
 
 .. code-block:: none
 
-  node index.js
+   node index.js
 
 When you run the command, the sample code should output the details of the
 movie which resembles the following:

--- a/source/quick-start.txt
+++ b/source/quick-start.txt
@@ -102,7 +102,7 @@ to set up a new Atlas account and a free tier cluster (MongoDB instance).
 Then, complete the :atlas:`Load Sample Data into Your Atlas Cluster </sample-data/?tck=docs_driver_nodejs>`
 guide to insert sample data into your cluster.
 
-After completing the steps these Atlas guides, you should have a new MongoDB
+After completing the steps in these Atlas guides, you should have a new MongoDB
 cluster deployed in Atlas, a new database user, and sample datasets loaded
 into your cluster.
 


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-15299

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/1c479b3/node/docsworker-xlarge/DOCSP-15299-atlas-sample-data-link/quick-start/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?
