### PR TITLE
need to sort on imdb.rating rather than rating

### DIFF
--- a/source/code-snippets/usage-examples/findOne.js
+++ b/source/code-snippets/usage-examples/findOne.js
@@ -18,7 +18,7 @@ async function run() {
 
     const options = {
       // sort matched documents in descending order by rating
-      sort: { rating: -1 },
+      sort: { "imdb.rating": -1 },
       // Include only the `title` and `imdb` fields in the returned document
       projection: { _id: 0, title: 1, imdb: 1 },
     };


### PR DESCRIPTION
## Pull Request 

Sort does not sort on a valid field. Needs to sort on "imdb.rating" rather than "rating".  "rating" is not a valid field in the sample dataset.

### Issue JIRA link:
NA

### Docs staging link (requires sign-in on MongoDB Corp SSO):

https://docs-mongodbcom-staging.corp.mongodb.com/8b555f3/node/docsworker-xlarge/Fix-Find-One-Incorrect-Sort/usage-examples/findOne/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?
