### PR TITLE
DOCSP-15723: changestream example syntax fix

### DIFF
--- a/source/usage-examples/changeStream.txt
+++ b/source/usage-examples/changeStream.txt
@@ -19,7 +19,7 @@ In the example below, the ``$match`` stage will match all change event documents
 
 .. code-block:: javascript
 
-   const pipeline = [ { $match: { runtime: { $lt: 15 } } ];
+   const pipeline = [ { $match: { runtime: { $lt: 15 } } } ];
    const changeStream = collection.watch(pipeline);
 
 The ``watch()`` method accepts an ``options`` object as the second parameter. Refer to the links at the end of this


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-15723

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/450c080/node/docsworker-xlarge/DOCSP-15723-changestream-fix/usage-examples/changeStream/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?
