### PR TITLE
DOCSP-12263 default time for KeepAliveInitialDelay

### DIFF
--- a/source/fundamentals/connection.txt
+++ b/source/fundamentals/connection.txt
@@ -141,7 +141,7 @@ URI to specify the behavior of the client.
 
    * - **keepAliveInitialDelay**
      - integer
-     - ``30000``
+     - ``12000``
      - Specifies the number of milliseconds to wait before initiating
        ``keepAlive`` on the TCP socket. For more information, see the
        documentation for `Node.js socket.setKeepAlive

--- a/source/fundamentals/connection.txt
+++ b/source/fundamentals/connection.txt
@@ -142,7 +142,7 @@ URI to specify the behavior of the client.
 
    * - **keepAliveInitialDelay**
      - integer
-     - ``12000``
+     - ``120000``
      - Specifies the number of milliseconds to wait before initiating
        ``keepAlive`` on the TCP socket. For more information, see the
        documentation for `Node.js socket.setKeepAlive


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-12263

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/b56fb45/node/docsworker-xlarge/DOCSP-12263-KeepAliveDefault/fundamentals/connection/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?
