### PR TITLE
DOCSP-16097 Clarifying Intro

### DIFF
--- a/source/usage-examples/find.txt
+++ b/source/usage-examples/find.txt
@@ -6,12 +6,12 @@ Find Multiple Documents
 
 You can query for multiple documents in a collection with the
 ``collection.find()`` method. The ``find()`` method uses a query
-document that contains one or more query operators to determine the
-documents to include in the result set. If you don't provide a query
-document or if you provide an empty document, MongoDB returns all
-documents in the collection. For more information on how to 
-specify query operators in a query document, see our
-:doc:`documentation on query documents
+document to determine what to include in the result set. Your query
+document can contain query operators. Query operators are keywords that
+begin with a ``$`` that let you specify complex query behavior. If you
+don't provide a query document or if you provide an empty document,
+MongoDB returns all documents in the collection. For more information on
+how to use query documents and query operators, see our :doc:`guide on query documents
 </fundamentals/crud/query-document>`. 
 
 You can also define additional query options such as

--- a/source/usage-examples/find.txt
+++ b/source/usage-examples/find.txt
@@ -4,13 +4,16 @@ Find Multiple Documents
 
 .. default-domain:: mongodb
 
-You can query for multiple documents in a collection with
-``collection.find()``. The ``find()`` method uses a query document that you
-provide to match the subset of the documents in the collection that match the
-query. If you don't provide a query document (or if you provide an empty
-document), MongoDB returns all documents in the collection. For more
-information on querying MongoDB, see our
-:doc:`documentation on query documents </fundamentals/crud/query-document>`.
+You can query for multiple documents in a collection by passing a
+query document to the ``collection.find()`` method. A query document
+contains one or more query operators that apply to specific fields which
+determine the documents to include in the result set. For more
+information, see our :doc:`documentation on query documents </fundamentals/crud/query-document>`.
+
+.. note::
+
+  If you don't provide a query document (or if you provide an empty
+  document), MongoDB returns all documents in the collection. 
 
 You can also define additional query options such as
 :doc:`sort </fundamentals/crud/read-operations/sort>`
@@ -58,11 +61,11 @@ following:
 
 .. code-block:: javascript
 
-   { title: '10 Minutes', imdb: { rating: 7.9, votes: 743, id: 339976 } }
-   { title: '3x3', imdb: { rating: 6.9, votes: 206, id: 1654725 } }
-   { title: '7:35 in the Morning', imdb: { rating: 7.3, votes: 1555, id: 406501 } }
-   { title: '8', imdb: { rating: 7.8, votes: 883, id: 1592502 } }
-   ...
+  { title: '10 Minutes', imdb: { rating: 7.9, votes: 743, id: 339976 } }
+  { title: '3x3', imdb: { rating: 6.9, votes: 206, id: 1654725 } }
+  { title: '7:35 in the Morning', imdb: { rating: 7.3, votes: 1555, id: 406501 } }
+  { title: '8', imdb: { rating: 7.8, votes: 883, id: 1592502 } }
+  ...
 
 The ``sort`` and ``projection`` options can also be specified as methods
 (``sort()`` and ``project()``, respectively) chained to the ``findOne`` method.
@@ -70,5 +73,5 @@ The following two commands are equivalent:
 
 .. code-block:: javascript
 
-   collection.find({ runtime: { $lt: 15 } }, { sort: { title: 1 }, projection: { _id: 0, title: 1, imdb: 1 }});
-   collection.find({ runtime: { $lt: 15 } }).sort({ title: 1}).project({ _id: 0, title: 1, imdb: 1 });
+  collection.find({ runtime: { $lt: 15 } }, { sort: { title: 1 }, projection: { _id: 0, title: 1, imdb: 1 }});
+  collection.find({ runtime: { $lt: 15 } }).sort({ title: 1}).project({ _id: 0, title: 1, imdb: 1 });

--- a/source/usage-examples/find.txt
+++ b/source/usage-examples/find.txt
@@ -6,7 +6,7 @@ Find Multiple Documents
 
 You can query for multiple documents in a collection with the
 ``collection.find()`` method. The ``find()`` method uses a query
-document to determine what to include in the result set. Your query
+document to determine what to include in the result set. A query
 document can contain query operators. Query operators are keywords that
 begin with a ``$`` that let you specify complex query behavior. If you
 don't provide a query document or if you provide an empty document,

--- a/source/usage-examples/find.txt
+++ b/source/usage-examples/find.txt
@@ -4,16 +4,15 @@ Find Multiple Documents
 
 .. default-domain:: mongodb
 
-You can query for multiple documents in a collection by passing a
-query document to the ``collection.find()`` method. A query document
-contains one or more query operators that apply to specific fields which
-determine the documents to include in the result set. For more
-information, see our :doc:`documentation on query documents </fundamentals/crud/query-document>`.
-
-.. note::
-
-  If you don't provide a query document (or if you provide an empty
-  document), MongoDB returns all documents in the collection. 
+You can query for multiple documents in a collection with the
+``collection.find()`` method. The ``find()`` method uses a query
+document that contains one or more query operators to determine the
+documents to include in the result set. If you don't provide a query
+document or if you provide an empty document, MongoDB returns all
+documents in the collection. For more information on how to 
+specify query operators in a query document, see our
+:doc:`documentation on query documents
+</fundamentals/crud/query-document>`. 
 
 You can also define additional query options such as
 :doc:`sort </fundamentals/crud/read-operations/sort>`
@@ -61,11 +60,11 @@ following:
 
 .. code-block:: javascript
 
-  { title: '10 Minutes', imdb: { rating: 7.9, votes: 743, id: 339976 } }
-  { title: '3x3', imdb: { rating: 6.9, votes: 206, id: 1654725 } }
-  { title: '7:35 in the Morning', imdb: { rating: 7.3, votes: 1555, id: 406501 } }
-  { title: '8', imdb: { rating: 7.8, votes: 883, id: 1592502 } }
-  ...
+   { title: '10 Minutes', imdb: { rating: 7.9, votes: 743, id: 339976 } }
+   { title: '3x3', imdb: { rating: 6.9, votes: 206, id: 1654725 } }
+   { title: '7:35 in the Morning', imdb: { rating: 7.3, votes: 1555, id: 406501 } }
+   { title: '8', imdb: { rating: 7.8, votes: 883, id: 1592502 } }
+   ...
 
 The ``sort`` and ``projection`` options can also be specified as methods
 (``sort()`` and ``project()``, respectively) chained to the ``findOne`` method.
@@ -73,5 +72,5 @@ The following two commands are equivalent:
 
 .. code-block:: javascript
 
-  collection.find({ runtime: { $lt: 15 } }, { sort: { title: 1 }, projection: { _id: 0, title: 1, imdb: 1 }});
-  collection.find({ runtime: { $lt: 15 } }).sort({ title: 1}).project({ _id: 0, title: 1, imdb: 1 });
+   collection.find({ runtime: { $lt: 15 } }, { sort: { title: 1 }, projection: { _id: 0, title: 1, imdb: 1 }});
+   collection.find({ runtime: { $lt: 15 } }).sort({ title: 1}).project({ _id: 0, title: 1, imdb: 1 });

--- a/source/usage-examples/findOne.txt
+++ b/source/usage-examples/findOne.txt
@@ -5,12 +5,12 @@ Find a Document
 .. default-domain:: mongodb
 
 .. note::
-  If you specify a callback method, ``findOne()`` returns nothing. If you do
-  not specify one, this method returns a ``Promise`` that resolves to the
-  result object when it completes. See our guide on :doc:`Promises and
-  Callbacks </fundamentals/promises>` for more information, or the
-  :node-api:`API documentation <Collection.html#~resultCallback>` for
-  information on the result object.
+   If you specify a callback method, ``findOne()`` returns nothing. If you do
+   not specify one, this method returns a ``Promise`` that resolves to the
+   result object when it completes. See our guide on :doc:`Promises and
+   Callbacks </fundamentals/promises>` for more information, or the
+   :node-api:`API documentation <Collection.html#~resultCallback>` for
+   information on the result object.
 
 You can query for a single document in a collection with the
 ``collection.findOne()`` method. The ``findOne()`` method uses a query

--- a/source/usage-examples/findOne.txt
+++ b/source/usage-examples/findOne.txt
@@ -16,9 +16,9 @@ You can query for a single document in a collection with the
 ``collection.findOne()`` method. The ``findOne()`` method uses a query
 document that contains one or more query operators to determine the
 document to include in the result set. If you don't provide a query
-document or if you provide an empty document, MongoDB returns all
-documents in the collection. For more information on how to 
-specify query operators in a query document, see our
+document or if you provide an empty document, MongoDB returns the first
+matched document. For more information on how to specify query
+operators in a query document, see our 
 :doc:`documentation on query documents
 </fundamentals/crud/query-document>`. 
 

--- a/source/usage-examples/findOne.txt
+++ b/source/usage-examples/findOne.txt
@@ -14,12 +14,12 @@ Find a Document
 
 You can query for a single document in a collection with the
 ``collection.findOne()`` method. The ``findOne()`` method uses a query
-document that contains one or more query operators to determine the
-document to include in the result set. If you don't provide a query
-document or if you provide an empty document, MongoDB returns the first
-matched document. For more information on how to specify query
-operators in a query document, see our 
-:doc:`documentation on query documents
+document to determine what to include in the result set. Your query
+document may contain query operators. Query operators are keywords that
+begin with a ``$`` that let you specify complex query behavior. If you
+don't provide a query document or if you provide an empty document,
+MongoDB returns the first matched document. For more information on how
+use query documents and query operators, see our :doc:`guide on query documents
 </fundamentals/crud/query-document>`. 
 
 You can also define additional query options such as

--- a/source/usage-examples/findOne.txt
+++ b/source/usage-examples/findOne.txt
@@ -5,21 +5,24 @@ Find a Document
 .. default-domain:: mongodb
 
 .. note::
-   If you specify a callback method, ``findOne()`` returns nothing. If you do
-   not specify one, this method returns a ``Promise`` that resolves to the
-   result object when it completes. See our guide on :doc:`Promises and
-   Callbacks </fundamentals/promises>` for more information, or the
-   :node-api:`API documentation <Collection.html#~resultCallback>` for
-   information on the result object.
+  If you specify a callback method, ``findOne()`` returns nothing. If you do
+  not specify one, this method returns a ``Promise`` that resolves to the
+  result object when it completes. See our guide on :doc:`Promises and
+  Callbacks </fundamentals/promises>` for more information, or the
+  :node-api:`API documentation <Collection.html#~resultCallback>` for
+  information on the result object.
 
-You can query for a single document in a collection with the
-``collection.findOne()`` method. The ``findOne()`` method uses a query
-document that you provide to match only the subset of the documents in the
-collection that match the query. If you don't provide a query document or if
-you provide an empty document, MongoDB matches all documents in the
-collection. The ``findOne()`` operation only returns the first matched
-document. For more information on querying MongoDB, see our
-:doc:`documentation on query documents </fundamentals/crud/query-document>`.
+You can query for a single document in a collection by passing a
+query document to the ``collection.findOne()`` method. A query document
+contains one or more query operators that apply to specific fields which
+determine the document to include in the result set. For more
+information, see our :doc:`documentation on query documents </fundamentals/crud/query-document>`.
+
+.. note::
+
+  If you don't provide a query document (or if you provide an empty
+  document), MongoDB returns the first document in the collection. 
+
 
 You can also define additional query options such as
 :doc:`sort </fundamentals/crud/read-operations/sort>`
@@ -49,12 +52,12 @@ collection. It uses the following parameters:
 .. include:: /includes/connect-guide-note.rst
 
 .. literalinclude:: /code-snippets/usage-examples/findOne.js
-   :language: javascript
+  :language: javascript
 
 If you run the example above, you should see a result that resembles the
 following:
 
 .. code-block:: javascript
 
-   { title: 'The Room', imdb: { rating: 3.5, votes: 25673, id: 368226 } }
+  { title: 'The Room', imdb: { rating: 3.5, votes: 25673, id: 368226 } }
 

--- a/source/usage-examples/findOne.txt
+++ b/source/usage-examples/findOne.txt
@@ -12,17 +12,15 @@ Find a Document
   :node-api:`API documentation <Collection.html#~resultCallback>` for
   information on the result object.
 
-You can query for a single document in a collection by passing a
-query document to the ``collection.findOne()`` method. A query document
-contains one or more query operators that apply to specific fields which
-determine the document to include in the result set. For more
-information, see our :doc:`documentation on query documents </fundamentals/crud/query-document>`.
-
-.. note::
-
-  If you don't provide a query document (or if you provide an empty
-  document), MongoDB returns the first document in the collection. 
-
+You can query for a single document in a collection with the
+``collection.findOne()`` method. The ``findOne()`` method uses a query
+document that contains one or more query operators to determine the
+document to include in the result set. If you don't provide a query
+document or if you provide an empty document, MongoDB returns all
+documents in the collection. For more information on how to 
+specify query operators in a query document, see our
+:doc:`documentation on query documents
+</fundamentals/crud/query-document>`. 
 
 You can also define additional query options such as
 :doc:`sort </fundamentals/crud/read-operations/sort>`
@@ -52,12 +50,12 @@ collection. It uses the following parameters:
 .. include:: /includes/connect-guide-note.rst
 
 .. literalinclude:: /code-snippets/usage-examples/findOne.js
-  :language: javascript
+   :language: javascript
 
 If you run the example above, you should see a result that resembles the
 following:
 
 .. code-block:: javascript
 
-  { title: 'The Room', imdb: { rating: 3.5, votes: 25673, id: 368226 } }
+   { title: 'The Room', imdb: { rating: 3.5, votes: 25673, id: 368226 } }
 

--- a/source/usage-examples/findOne.txt
+++ b/source/usage-examples/findOne.txt
@@ -14,8 +14,8 @@ Find a Document
 
 You can query for a single document in a collection with the
 ``collection.findOne()`` method. The ``findOne()`` method uses a query
-document to determine what to include in the result set. Your query
-document may contain query operators. Query operators are keywords that
+document to determine what to include in the result set. A query
+document can contain query operators. Query operators are keywords that
 begin with a ``$`` that let you specify complex query behavior. If you
 don't provide a query document or if you provide an empty document,
 MongoDB returns the first matched document. For more information on how


### PR DESCRIPTION
## Pull Request Info
Clarified the intro of both Usage Examples > Find Operation pages.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-16097

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/7cb12b0/node/docsworker-xlarge/DOCSP-16097-ClarifyQueryOps/usage-examples/findOne/

https://docs-mongodbcom-staging.corp.mongodb.com/7cb12b0/node/docsworker-xlarge/DOCSP-16097-ClarifyQueryOps/usage-examples/find/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?
