### PR TITLE
DOCS-14237 max time ms note

### DIFF
--- a/source/faq.txt
+++ b/source/faq.txt
@@ -45,15 +45,20 @@ What Is the Difference Between "connectTimeoutMS", "socketTimeoutMS" and "maxTim
        specified time limit, it returns a timeout error.
 
 To specify the optional settings for your ``MongoClient``, declare one or
-more of them in the ``options`` object of the constructor as follows:
+more available options in the ``options`` object of the constructor as follows:
 
 .. code-block:: javascript
 
    const client = new MongoClient(uri, {
      connectTimeoutMS: <integer value>,
-     socketTimeoutMS: <integer value>,
-     maxTimeMS: <integer value>,
+     socketTimeoutMS: <integer value>
    });
+
+.. note::
+
+  ``maxTimeMS`` is not an available option in MongoClientOptions. To see
+  the available options, see the :node-api-3.6:`MongoClientOptions
+  <global.html#MongoClientOptions>` API Documentation. 
 
 
 How Can I Prevent the Driver From Hanging During Connection or From Spending Too Long Trying to Reach Unreachable Replica Sets?

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -45,7 +45,8 @@ What Is the Difference Between "connectTimeoutMS", "socketTimeoutMS" and "maxTim
        specified time limit, it returns a timeout error.
 
 To specify the optional settings for your ``MongoClient``, declare one or
-more available options in the ``options`` object of the constructor as follows:
+more available settings in the ``options`` object of the constructor as
+follows: 
 
 .. code-block:: javascript
 
@@ -54,13 +55,9 @@ more available options in the ``options`` object of the constructor as follows:
      socketTimeoutMS: <integer value>
    });
 
-.. note::
-
-  ``maxTimeMS`` is not an available option for your ``MongoClient``
-  settings. To see the available options, see the
-  :node-api-3.6:`MongoClientOptions <global.html#MongoClientOptions>`
-  API Documentation. 
-
+To see all the available settings, see the
+:node-api-3.6:`MongoClientOptions <global.html#MongoClientOptions>` API
+Documentation.  
 
 How Can I Prevent the Driver From Hanging During Connection or From Spending Too Long Trying to Reach Unreachable Replica Sets?
 -------------------------------------------------------------------------------------------------------------------------------

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -56,9 +56,10 @@ more available options in the ``options`` object of the constructor as follows:
 
 .. note::
 
-  ``maxTimeMS`` is not an available option in MongoClientOptions. To see
-  the available options, see the :node-api-3.6:`MongoClientOptions
-  <global.html#MongoClientOptions>` API Documentation. 
+  ``maxTimeMS`` is not an available option for your ``MongoClient``
+  settings. To see the available options, see the
+  :node-api-3.6:`MongoClientOptions <global.html#MongoClientOptions>`
+  API Documentation. 
 
 
 How Can I Prevent the Driver From Hanging During Connection or From Spending Too Long Trying to Reach Unreachable Replica Sets?


### PR DESCRIPTION
## Pull Request Info
Added a note that you cannot use maxTimeMS for MongoClientSettings.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-14237

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/73de378/node/docsworker-xlarge/DOCS-14237-maxTimeMSNote/faq/#what-is-the-difference-between--connecttimeoutms----sockettimeoutms--and--maxtimems--

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?
