### PR TITLE
DOSCP-17299 node usage grammar fix

### DIFF
--- a/source/code-snippets/usage-examples/updateOne.js
+++ b/source/code-snippets/usage-examples/updateOne.js
@@ -23,7 +23,7 @@ async function run() {
     const updateDoc = {
       $set: {
         plot:
-          "Blacksmith Scene is a silent film directed by William K.L. Dickson",
+          "Blacksmith Scene is a silent film directed by William K.L. Dickson.",
       },
     };
 

--- a/source/usage-examples/updateMany.txt
+++ b/source/usage-examples/updateMany.txt
@@ -14,7 +14,7 @@ Update Multiple Documents
 
 You can update multiple documents using the
 :node-api-4.0:`collection.updateMany() </classes/collection.html#updatemany>` method.
-The ``updateMany()`` method accepts a filter object and update document, and
+The ``updateMany()`` method accepts a filter object and update document and
 replaces documents in a collection that match the filter with the update
 document. The update document requires an :manual:`update operator
 </reference/operator/update>` to modify a field in a document.

--- a/source/usage-examples/updateMany.txt
+++ b/source/usage-examples/updateMany.txt
@@ -8,13 +8,13 @@ Update Multiple Documents
    If you specify a callback method, ``updateMany()`` returns nothing. If you
    do not specify one, this method returns a ``Promise`` that resolves to the
    result object when it completes. See our guide on :doc:`Promises and
-   Callbacks </fundamentals/promises>` for more information, or the
+   Callbacks </fundamentals/promises>` for more information, or see the
    :node-api-4.0:`API documentation </classes/collection.html#~resultcallback>` for
    information on the result object.
 
 You can update multiple documents using the
-:node-api-4.0:`updateMany() </classes/collection.html#updatemany>` method.
-``updateMany()`` accepts a filter object and update document, and
+:node-api-4.0:`collection.updateMany() </classes/collection.html#updatemany>` method.
+The `updateMany()`` method accepts a filter object and update document, and
 replaces documents in a collection that match the filter with the update
 document. The update document requires an :manual:`update operator
 </reference/operator/update>` to modify a field in a document.

--- a/source/usage-examples/updateMany.txt
+++ b/source/usage-examples/updateMany.txt
@@ -14,9 +14,9 @@ Update Multiple Documents
 
 You can update multiple documents using the
 :node-api-4.0:`collection.updateMany() </classes/collection.html#updatemany>` method.
-The ``updateMany()`` method accepts a filter object and update document and
-then replaces documents in a collection that match the filter with the update
-document. The update document requires an :manual:`update operator
+The ``updateMany()`` method accepts a filter document and an update document. If the query matches documents in the
+collection, the method applies the updates from the update document to fields
+and values of the matching documents. The update document requires an :manual:`update operator
 </reference/operator/update>` to modify a field in a document.
 
 You can specify additional options in the ``options`` object passed in

--- a/source/usage-examples/updateMany.txt
+++ b/source/usage-examples/updateMany.txt
@@ -15,7 +15,7 @@ Update Multiple Documents
 You can update multiple documents using the
 :node-api-4.0:`collection.updateMany() </classes/collection.html#updatemany>` method.
 The ``updateMany()`` method accepts a filter object and update document and
-replaces documents in a collection that match the filter with the update
+then replaces documents in a collection that match the filter with the update
 document. The update document requires an :manual:`update operator
 </reference/operator/update>` to modify a field in a document.
 

--- a/source/usage-examples/updateMany.txt
+++ b/source/usage-examples/updateMany.txt
@@ -14,7 +14,7 @@ Update Multiple Documents
 
 You can update multiple documents using the
 :node-api-4.0:`collection.updateMany() </classes/collection.html#updatemany>` method.
-The `updateMany()`` method accepts a filter object and update document, and
+The ``updateMany()`` method accepts a filter object and update document, and
 replaces documents in a collection that match the filter with the update
 document. The update document requires an :manual:`update operator
 </reference/operator/update>` to modify a field in a document.

--- a/source/usage-examples/updateOne.txt
+++ b/source/usage-examples/updateOne.txt
@@ -8,13 +8,13 @@ Update a Document
    If you specify a callback method, ``updateOne()`` returns nothing. If you
    do not specify one, this method returns a ``Promise`` that resolves to the
    result object when it completes. See our guide on :doc:`Promises and
-   Callbacks </fundamentals/promises>` for more information, or the
+   Callbacks </fundamentals/promises>` for more information, or see the
    :node-api-4.0:`API documentation </classes/collection.html#~updatewriteopresult>` for
    information on the result object.
 
 You can update a single document using the 
 :node-api-4.0:`collection.updateOne() </classes/collection.html#updateone>`
-method. ``updateOne()`` accepts a filter
+method. The ``updateOne()`` method accepts a filter
 document and an update document. If the query matches documents in the
 collection, the method applies the updates from the update document to fields
 and values of them. The update document contains :manual:`update operators


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-17299

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-17299-node-usage-grammar-fix/usage-examples/updateOne/
https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-17299-node-usage-grammar-fix/usage-examples/updateMany/

### Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Does it render on staging correctly?
- [ ] Are all the links working?
- [ ] Are the staging links in the PR description updated?
