### PR TITLE
DOCSP-17414: ChangeStream paradim errors

### DIFF
--- a/source/includes/changestream-paradigm-warning.rst
+++ b/source/includes/changestream-paradigm-warning.rst
@@ -2,7 +2,7 @@
 
    Using a ``ChangeStream`` in ``EventEmitter`` and ``Iterator`` mode
    concurrently is not supported and causes an error. This is to prevent
-   undefined behavior, where it cannot be guaranteed which consumer will
-   receive documents first.
+   undefined behavior, where the driver cannot guarantee which consumer
+   receives documents first.
 
 

--- a/source/includes/changestream-paradigm-warning.rst
+++ b/source/includes/changestream-paradigm-warning.rst
@@ -1,4 +1,8 @@
 .. warning::
 
-   Attempting to use a ``ChangeStream`` as an ``Iterator`` that is in ``EventEmitter`` mode will cause an error,
-   and attempting to use a ``ChangeStream`` as an ``EventEmitter`` in ``Iterator`` mode will cause an error.
+   Using a ``ChangeStream`` in ``EventEmitter`` and ``Iterator`` mode
+   concurrently is not supported and causes an error. This is to prevent
+   undefined behavior, where it cannot be guaranteed which consumer will
+   receive documents first.
+
+

--- a/source/includes/changestream-paradigm-warning.rst
+++ b/source/includes/changestream-paradigm-warning.rst
@@ -1,0 +1,4 @@
+.. warning::
+
+   Attempting to use a ``ChangeStream`` as an ``Iterator`` that is in ``EventEmitter`` mode will cause an error,
+   and attempting to use a ``ChangeStream`` as an ``EventEmitter`` in ``Iterator`` mode will cause an error.

--- a/source/includes/changestream-paradigm-warning.rst
+++ b/source/includes/changestream-paradigm-warning.rst
@@ -1,8 +1,8 @@
 .. warning::
 
    Using a ``ChangeStream`` in ``EventEmitter`` and ``Iterator`` mode
-   concurrently is not supported and causes an error. This is to prevent
-   undefined behavior, where the driver cannot guarantee which consumer
-   receives documents first.
+   concurrently is not supported by the driver and causes an error. This
+   is to prevent undefined behavior, where the driver cannot guarantee
+   which consumer receives documents first.
 
 

--- a/source/usage-examples/changeStream.txt
+++ b/source/usage-examples/changeStream.txt
@@ -29,10 +29,7 @@ The ``watch()`` method returns an instance of a :node-api-4.0:`ChangeStream </cl
 change streams by iterating over them or listening for events. Select the tab that corresponds to the way you want to
 read events from the change stream below.
 
-.. warning::
-
-   Avoid mixing both the iterative and event-based approach of reading from change streams as it can cause unexpected
-   behavior.
+.. include:: /includes/changestream-paradigm-warning.rst
 
 .. tabs::
 


### PR DESCRIPTION
This changes the warning text to state that mixing paradigms will error. [Upstream PR](https://github.com/mongodb/node-mongodb-native/pull/2871)

## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-17414

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-17414/usage-examples/changeStream/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?
