### PR TITLE
correct port transposition error

### DIFF
--- a/source/includes/localhost-connection.rst
+++ b/source/includes/localhost-connection.rst
@@ -1,5 +1,5 @@
 To connect to a ``mongod`` running locally, change the connection string
-to ``"mongodb://localhost:<port>"``, e.g. ``"mongodb://localhost:27107"``.
+to ``"mongodb://localhost:<port>"``, e.g. ``"mongodb://localhost:27017"``.
 
 Your ``mongod`` instance must be running to successfully connect to your
 database. For information on how to start your ``mongod`` instance,


### PR DESCRIPTION
## Pull Request Info

Changes the localhost note to use port 27017 instead of 27107.

:fire: This is only on the v3.6 branch, not the master branch.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCS-14637

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCS-14637/quick-start/#connect-to-localhost

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?
