### PR TITLE
DOCSP-17505: correct $lt description

### DIFF
--- a/source/fundamentals/crud/query-document.txt
+++ b/source/fundamentals/crud/query-document.txt
@@ -9,7 +9,7 @@ Specify a Query
    :backlinks: none
    :depth: 1
    :class: singlecol
-   
+
 Overview
 --------
 
@@ -93,10 +93,10 @@ Comparison Operators
 
 Comparison operators allow you to query for data based on comparisons
 with values in a collection. Common comparison operators include
-``$gt`` for "greater than" comparisons, ``$lt`` for "less than or equal
-to" comparisons, and ``$ne`` for "not equal to " comparisons. The
-following operation uses the comparison operator ``$gt`` to search for
-documents with a quantity value greater than 5 and prints them out:
+``$gt`` for "greater than" comparisons, ``$lt`` for "less than" comparisons,
+and ``$ne`` for "not equal to " comparisons. The following operation uses
+the comparison operator ``$gt`` to search for documents with a quantity
+value greater than 5 and prints them out:
 
 .. code-block:: javascript
 

--- a/source/fundamentals/crud/query-document.txt
+++ b/source/fundamentals/crud/query-document.txt
@@ -94,7 +94,7 @@ Comparison Operators
 Comparison operators allow you to query for data based on comparisons
 with values in a collection. Common comparison operators include
 ``$gt`` for "greater than" comparisons, ``$lt`` for "less than" comparisons,
-and ``$ne`` for "not equal to " comparisons. The following operation uses
+and ``$ne`` for "not equal to" comparisons. The following operation uses
 the comparison operator ``$gt`` to search for documents with a quantity
 value greater than 5 and prints them out:
 
@@ -119,7 +119,7 @@ Logical Operators
 Logical operators allow you to query for data using logic applied to the
 results of field-level operators. For instance, you can use the ``$or``
 method to query for documents that match either a ``$gt`` comparison
-operators or a literal value query. The following operation uses the
+operator or a literal value query. The following operation uses the
 logical operator ``$not`` to search for documents with a quantity value
 that is not greater than 5 and prints them out:
 


### PR DESCRIPTION
## Pull Request Info

Correctly describes the `$lt` operator.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-17505

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-17505/fundamentals/crud/query-document/#comparison-operators

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?
