### PR TITLE
fixed api documentation version

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -13,7 +13,7 @@ MongoDB Node Driver
   /quick-start
   /usage-examples
   /fundamentals
-  API Documentation <https://mongodb.github.io/node-mongodb-native/4.0/>
+  API Documentation <http://mongodb.github.io/node-mongodb-native/3.6/api/>
   /faq
   /issues-and-help
   /compatibility

--- a/source/index.txt
+++ b/source/index.txt
@@ -13,7 +13,7 @@ MongoDB Node Driver
   /quick-start
   /usage-examples
   /fundamentals
-  API Documentation <http://mongodb.github.io/node-mongodb-native/3.6/api/>
+  API Documentation <https://mongodb.github.io/node-mongodb-native/3.6/api/>
   /faq
   /issues-and-help
   /compatibility


### PR DESCRIPTION
## Pull Request Info
Fixed error I made with the API documentation version when cherry-picking.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-17643 

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/APIDocumentaionVersion/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?
