### PR TITLE
DOCSP-17406 listing available usage examples

### DIFF
--- a/source/usage-examples.txt
+++ b/source/usage-examples.txt
@@ -71,3 +71,16 @@ usage example. If your instance uses :manual:`SCRAM authentication
 address or URL of your instance. Consult the
 :doc:`Connection Guide </fundamentals/connection>` for more information
 about getting connected to your MongoDB instance.
+
+Available Usage Examples
+------------------------
+
+- :doc:`Find Operations </usage-examples/find-operations>`
+- :doc:`Insert Operations </usage-examples/insert-operations>`
+- :doc:`Update Operations </usage-examples/update-and-replace-operations>`
+- :doc:`Delete Operations </usage-examples/delete-operations>`
+- :doc:`Count Documents </usage-examples/count>`
+- :doc:`Retrieve Distinct Values of a Field </usage-examples/distinct>`
+- :doc:`Run a Command </usage-examples/command>`
+- :doc:`Watch for Changes </usage-examples/changeStream>`
+- :doc:`Perform Bulk Operations </usage-examples/bulkWrite>`


### PR DESCRIPTION
## Pull Request Info

Listed all available usage examples on the page for the reader to easily find.

I followed the format of how the Java builders page lists the pages within it's section: https://docs.mongodb.com/drivers/java/sync/current/fundamentals/builders/#available-builders

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-17406

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-17406-ListingUsageExamples/usage-examples/#available-usage-examples

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?
