### PR TITLE
DOCSP-17885 broken links

### DIFF
--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -170,8 +170,7 @@ operator instead.
 Authentication
 ++++++++++++++
 
-- ``gssapiServiceName`` is now removed. Use :node-api-4.0:`authMechanismProperties.SERVICE_NAME` in the URI
-  or as an option on ``MongoClientOptions``.
+- ``gssapiServiceName`` is now removed. Use :node-api-4.0:`authMechanismProperties.SERVICE_NAME <interfaces/mongoclientoptions.html#authmechanismproperties>` in the URI or as an option on ``MongoClientOptions``.
 
   .. example::
 
@@ -297,7 +296,7 @@ Unified Topology
 
 - It is longer required to specify ``useUnifiedTopology`` or ``useNewUrlParser``.
 
-- You must use the new ``directConnection`` :node-api-4.0:`option </mongoclientoptions.html#directconnection>`
+- You must use the new ``directConnection`` :node-api-4.0:`option <interfaces/mongoclientoptions.html#directconnection>`
   to connect to unitiliazed replica set members.
 
 Explain
@@ -330,7 +329,7 @@ New features of the 3.6 Node.js driver release include:
 
 - Added support for the :ref:`MONGODB-AWS <mongodb-aws>` authentication mechanism using Amazon Web Services (AWS) Identity and Access Management (IAM) credentials
 - Added support for Online Certificate Status Protocol (OCSP)
-- The :node-api-4.0:`find()</classes/collection.html#find>` method supports ``allowDiskUse()`` for sorts that require too much memory to execute in RAM
+- The :node-api-4.0:`find() <classes/collection.html#find>` method supports ``allowDiskUse()`` for sorts that require too much memory to execute in RAM
 - The :ref:`update() <updateDocuments>` and :ref:`replaceOne() <replacementDocument>` methods support index hints
 - A reduction in recovery time for topology changes and failover events
 - Improvements in validation testing for the default :manual:`writeConcern </reference/write-concern/>`


### PR DESCRIPTION
## Pull Request Info

Fixed:
- a broken link a user reported 
- a broken link I found
- a trailing / in the 3.6 section

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-17885

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-17885-brokenLinks/whats-new/#authentication

https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-17885-brokenLinks/whats-new/#unified-topology

https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-17885-brokenLinks/whats-new/#what-s-new-in-3.6

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?
