### PR TITLE
Fixed directives in v3.6 to link to 3.6 API docs

### DIFF
--- a/source/fundamentals/aggregation.txt
+++ b/source/fundamentals/aggregation.txt
@@ -54,7 +54,7 @@ Aggregation operations have some :manual:`limitations </core/aggregation-pipelin
 
 - Pipeline stages have a memory limit of 100 megabytes by default. If necessary, you may exceed this limit by setting the ``allowDiskUse``
   property of ``AggregateOptions`` to ``true``. See the
-  :node-api-4.0:`AggregateOptions API documentation <interfaces/aggregateoptions.html>`
+  :node-api-3.6:`AggregateOptions API documentation <interfaces/aggregateoptions.html>`
   for more details.
 
 .. important:: ``$graphLookup`` exception
@@ -117,7 +117,7 @@ This example should produce the following output:
    { _id: 3, count: 1 }
    { _id: 5, count: 1 }
    
-For more information, see the :node-api-4.0:`aggregate() API documentation <classes/collection.html#aggregate>`.
+For more information, see the :node-api-3.6:`aggregate() API documentation <classes/collection.html#aggregate>`.
 
 Additional Aggregation Examples
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/fundamentals/gridfs.txt
+++ b/source/fundamentals/gridfs.txt
@@ -94,7 +94,7 @@ default name ``fs``, as shown in the following example:
 
    const bucket = new mongodb.GridFSBucket(db, { bucketName: 'myCustomBucket' });
 
-For more information, see the :node-api-4.0:`GridFSBucket API documentation <classes/gridfsbucket.html>`.
+For more information, see the :node-api-3.6:`GridFSBucket API documentation <classes/gridfsbucket.html>`.
 
 .. _gridfs-upload-files:
 
@@ -117,7 +117,7 @@ following code snippet:
             metadata: { field: 'myField', value: 'myValue' }
         });
 
-See the :node-api-4.0:`openUploadStream() API documentation <classes/gridfsbucket.html#openuploadstream>` for more information.
+See the :node-api-3.6:`openUploadStream() API documentation <classes/gridfsbucket.html#openuploadstream>` for more information.
 
 .. _gridfs-retrieve-file-info:
 
@@ -154,8 +154,8 @@ combined with other methods such as ``sort()``, ``limit()``, and ``project()``.
 For more information on the classes and methods mentioned in this section,
 see the following resources:
 
-- :node-api-4.0:`find() API documentation <classes/gridfsbucket.html#find>`
-- :node-api-4.0:`FindCursor API documentation <classes/findcursor.html>`
+- :node-api-3.6:`find() API documentation <classes/gridfsbucket.html#find>`
+- :node-api-3.6:`FindCursor API documentation <classes/findcursor.html>`
 - :doc:`Cursor Fundamentals page </fundamentals/crud/read-operations/cursor>`
 - :doc:`Read Operations page </fundamentals/crud/read-operations/>`
 
@@ -200,7 +200,7 @@ method, which takes the ``_id`` field of a file as a parameter:
    overhead.
 
 For more information on the ``openDownloadStreamByName()`` method, see
-its :node-api-4.0:`API documentation <classes/gridfsbucket.html#opendownloadstreambyname>`.
+its :node-api-3.6:`API documentation <classes/gridfsbucket.html#opendownloadstreambyname>`.
 
 .. _gridfs-rename-files:
 
@@ -226,7 +226,7 @@ The following example shows how to update the ``filename`` field to
 
    bucket.rename(ObjectId("60edece5e06275bf0463aaf3"), "newFileName");
 
-For more information on this method, see the :node-api-4.0:`rename() API
+For more information on this method, see the :node-api-3.6:`rename() API
 documentation <classes/gridfsbucket.html#rename>`.
 
 .. _gridfs-delete-files:
@@ -250,7 +250,7 @@ The following example shows you how to delete a file by referencing its ``_id`` 
 
    bucket.delete(ObjectId("60edece5e06275bf0463aaf3"));
 
-For more information on this method, see the :node-api-4.0:`delete() API
+For more information on this method, see the :node-api-3.6:`delete() API
 documentation <classes/gridfsbucket.html#delete>`.
 
 .. _gridfs-delete-bucket:
@@ -266,7 +266,7 @@ code example shows you how to delete a GridFS bucket:
 
    bucket.drop();
 
-For more information on this method, see the :node-api-4.0:`drop() API
+For more information on this method, see the :node-api-3.6:`drop() API
 documentation </classes/gridfsbucket.html#drop>`.
 
 Additional Resources

--- a/source/usage-examples/updateMany.txt
+++ b/source/usage-examples/updateMany.txt
@@ -9,11 +9,11 @@ Update Multiple Documents
    do not specify one, this method returns a ``Promise`` that resolves to the
    result object when it completes. See our guide on :doc:`Promises and
    Callbacks </fundamentals/promises>` for more information, or see the
-   :node-api-4.0:`API documentation </classes/collection.html#~resultcallback>` for
+   :node-api-3.6:`API documentation </classes/collection.html#~resultcallback>` for
    information on the result object.
 
 You can update multiple documents using the
-:node-api-4.0:`collection.updateMany() </classes/collection.html#updatemany>` method.
+:node-api-3.6:`collection.updateMany() </classes/collection.html#updatemany>` method.
 The ``updateMany()`` method accepts a filter document and an update document. If the query matches documents in the
 collection, the method applies the updates from the update document to fields
 and values of the matching documents. The update document requires an :manual:`update operator

--- a/source/usage-examples/updateOne.txt
+++ b/source/usage-examples/updateOne.txt
@@ -9,11 +9,11 @@ Update a Document
    do not specify one, this method returns a ``Promise`` that resolves to the
    result object when it completes. See our guide on :doc:`Promises and
    Callbacks </fundamentals/promises>` for more information, or see the
-   :node-api-4.0:`API documentation </classes/collection.html#~updatewriteopresult>` for
+   :node-api-3.6:`API documentation </classes/collection.html#~updatewriteopresult>` for
    information on the result object.
 
 You can update a single document using the 
-:node-api-4.0:`collection.updateOne() </classes/collection.html#updateone>`
+:node-api-3.6:`collection.updateOne() </classes/collection.html#updateone>`
 method. The ``updateOne()`` method accepts a filter
 document and an update document. If the query matches documents in the
 collection, the method applies the updates from the update document to fields


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-NNNNN

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/directive-fix/

### Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Does it render on staging correctly?
- [ ] Are all the links working?
- [ ] Are the staging links in the PR description updated?
