### PR TITLE
Fix link to Node ServerApi interface

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -7,3 +7,4 @@ toc_landing_pages = ["/fundamentals/authentication", "/fundamentals", "/fundamen
 version = 4.0
 package-name-org = "mongodb-org"
 pgp-version = "{+version+}"
+node-api = "https://mongodb.github.io/node-mongodb-native/{+version+}"

--- a/source/fundamentals/versioned-api.txt
+++ b/source/fundamentals/versioned-api.txt
@@ -134,4 +134,4 @@ interface.
 For more information on the options in this section, see the following
 API Documentation:
 
-- `ServerApi <:{+node-api+}/interfaces/serverapi.html>`__
+- `ServerApi <{+node-api+}/interfaces/serverapi.html>`__

--- a/source/fundamentals/versioned-api.txt
+++ b/source/fundamentals/versioned-api.txt
@@ -134,4 +134,4 @@ interface.
 For more information on the options in this section, see the following
 API Documentation:
 
-- :java-docs:`ServerApi </interfaces/serverapi.html>`
+- `ServerApi <:{+node-api+}/interfaces/serverapi.html>`__


### PR DESCRIPTION
## Pull Request Info
This corrects the link for the ServerApi interface on the versioned API page.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-17971

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-17971/fundamentals/versioned-api/

### Self-Review Checklist

- [x] Is this[ free of any warnings or error](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=610d43bb7814dfcacd2a5e4a)s in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?
