### PR TITLE
DOCSP-17791: update instructions on connecting to locally hosted server

### DIFF
--- a/source/fundamentals/connection.txt
+++ b/source/fundamentals/connection.txt
@@ -53,16 +53,22 @@ options as parameters. In the example above, we set two connection options:
 ``poolSize=20`` and ``writeConcern=majority``. For more information on connection
 options, skip to the :ref:`connection-options` section.
 
+.. _connect-atlas-node-driver:
+
 The code below shows how you can use the sample connection URI in a client to
 connect to MongoDB.
 
 .. literalinclude:: /code-snippets/connection/srv.js
    :language: javascript
 
-Connect to ``localhost``
-++++++++++++++++++++++++
+Connect to a MongoDB Server on Your Local Machine
++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. include:: /includes/localhost-connection.rst
+
+To test whether you can connect to your server, replace the connection
+string in the :ref:`Connect to MongoDB Atlas <connect-atlas-node-driver>` code
+example and run it.
 
 ------------------------
 Connect to a Replica Set

--- a/source/fundamentals/connection.txt
+++ b/source/fundamentals/connection.txt
@@ -61,8 +61,17 @@ connect to MongoDB.
 .. literalinclude:: /code-snippets/connection/srv.js
    :language: javascript
 
+.. _node-other-ways-to-connect:
+
+Other Ways to Connect to MongoDB
+--------------------------------
+
+If you are connecting to a single MongoDB server instance or replica set
+that is not hosted on Atlas, see the following sections to find out how to
+connect.
+
 Connect to a MongoDB Server on Your Local Machine
-+++++++++++++++++++++++++++++++++++++++++++++++++
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. include:: /includes/localhost-connection.rst
 
@@ -70,9 +79,8 @@ To test whether you can connect to your server, replace the connection
 string in the :ref:`Connect to MongoDB Atlas <connect-atlas-node-driver>` code
 example and run it.
 
-------------------------
 Connect to a Replica Set
-------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 A MongoDB replica set deployment is a group of connected instances that
 store the same set of data. This configuration of instances provides data

--- a/source/fundamentals/connection.txt
+++ b/source/fundamentals/connection.txt
@@ -5,7 +5,7 @@ Connection Guide
 .. contents:: On this page
    :local:
    :backlinks: none
-   :depth: 2
+   :depth: 3
    :class: singlecol
 
 This guide shows you how to connect to a MongoDB instance or replica set

--- a/source/includes/localhost-connection.rst
+++ b/source/includes/localhost-connection.rst
@@ -1,8 +1,27 @@
-To connect to a ``mongod`` running locally, change the connection string
-to ``"mongodb://localhost:<port>"``, e.g. ``"mongodb://locahost:27017"``.
+If you need to run a MongoDB server on your local machine for development
+purposes instead of using an Atlas cluster, you need to complete the following:
 
-Your ``mongod`` instance must be running to successfully connect to your
-database. For information on how to start your ``mongod`` instance,
-see the :manual:`Manage mongod Processes
-</tutorial/manage-mongodb-processes/#start-mongod-processes>` Server
-Manual Entry.
+1. Download the `Community <https://www.mongodb.com/try/download/community>`__
+   or `Enterprise <https://www.mongodb.com/try/download/enterprise>`__ version
+   of MongoDB Server.
+
+#. `Install and configure <https://docs.mongodb.com/manual/installation/>`__
+   MongoDB Server.
+
+#. Start the server.
+
+.. important::
+
+   Always secure your MongoDB server from malicious attacks. See our
+   :manual:`Security Checklist </administration/security-checklist/>` for a
+   list of security recommendations.
+
+After you successfully start your MongoDB server, specify your connection
+string in your driver connection code.
+
+If your MongoDB Server is running locally, you can use the connection string
+``"mongodb://localhost:<port>"`` where ``<port>`` is the port number you
+configured your server to listen for incoming connections.
+
+If you need to specify a different hostname or IP address, see our Server
+Manual entry on :manual:`Connection Strings </reference/connection-string/>`.

--- a/source/quick-start.txt
+++ b/source/quick-start.txt
@@ -119,7 +119,7 @@ includes information on the hostname or IP address and port of your
 instance, authentication mechanism, user credentials when applicable, and
 other connection options.
 
-If you are connecting to an instance or cluster  that is not hosted by Atlas,
+If you are connecting to an instance or cluster that is not hosted by Atlas,
 see the :doc:`Connection Guide </fundamentals/connection>` for instructions on
 how to format your connection string.
 

--- a/source/quick-start.txt
+++ b/source/quick-start.txt
@@ -120,8 +120,8 @@ instance, authentication mechanism, user credentials when applicable, and
 other connection options.
 
 If you are connecting to an instance or cluster that is not hosted by Atlas,
-see the :doc:`Connection Guide </fundamentals/connection>` for instructions on
-how to format your connection string.
+see :ref:`Other Ways to Connect to MongoDB <node-other-ways-to-connect>` for
+instructions on how to format your connection string.
 
 To retrieve your connection string for the instance and user you created in
 the previous step, log into your Atlas account and navigate to the

--- a/source/quick-start.txt
+++ b/source/quick-start.txt
@@ -119,6 +119,10 @@ includes information on the hostname or IP address and port of your
 instance, authentication mechanism, user credentials when applicable, and
 other connection options.
 
+If you are connecting to an instance or cluster  that is not hosted by Atlas,
+see the :doc:`Connection Guide </fundamentals/connection>` for instructions on
+how to format your connection string.
+
 To retrieve your connection string for the instance and user you created in
 the previous step, log into your Atlas account and navigate to the
 **Clusters** section and click the **Connect** button for the cluster that you
@@ -211,11 +215,6 @@ cluster.
 After completing this step, you should have a working application that uses
 the Node.js driver to connect to your MongoDB instance, run a query on the
 sample data, and prints out the result.
-
-Connect to ``localhost``
-------------------------
-
-.. include:: /includes/localhost-connection.rst
 
 Next Steps
 ----------

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -23,8 +23,10 @@ What's New in 4.1
 
 New features of the 4.1 Node.js driver release include:
 
-- Added support for load balancer support to use in the beta :atlas:`Serverless platform </choose-database-deployment-type/>`
-- Added support for the ``advanceClusterTime()`` method to determine if the ``ClientSession`` should update its cluster time
+- Added load balanced connection support for all cluster types including
+  the beta :atlas:`Serverless platform </choose-database-deployment-type/?tck=docs_driver_nodejs>`.
+- Added support for the ``advanceClusterTime()`` method to determine if
+  the ``ClientSession`` should update its cluster time.
 
 .. _version-4.0:
 


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-17791

### Docs staging link (requires sign-in on MongoDB Corp SSO):
[Quick Start](https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-17791-new-local-instructions/quick-start/)

[Connection Guide](https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-17791-new-local-instructions/fundamentals/connection/)

[Build Log](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=611172827dcf012930215135)

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?
