### PR TITLE
DOCSP-17837 link fix

### DIFF
--- a/source/fundamentals/logging.txt
+++ b/source/fundamentals/logging.txt
@@ -12,9 +12,11 @@ Logging
 
 .. important::
 
-  The driver doesn't use the logger in this version. Attempting to use
-  prior settings in this version won't print anything. Instead, see our
-  monitoring guides:
+  The driver doesn't use the logger in versions 4.0 and later.
+  Attempting to use prior logger settings in this version won't print
+  anything in the log.
+  
+  Instead, see our monitoring guides:
 
   - :doc:`Command Monitoring </fundamentals/monitoring/command-monitoring>` 
   - :doc:`Cluster Monitoring </fundamentals/monitoring/cluster-monitoring>`
@@ -27,7 +29,9 @@ meantime, you can output monitor events using the following snippet:
 
 .. code-block:: javascript
 
-  const client = new MongoClient(CONNECTION_STRING, { monitorCommands:true });
+  const uri = "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
+  const client = new MongoClient(uri, { monitorCommands:true });
+  
   client.on('commandStarted', (event) => console.debug(event));
   client.on('commandSucceeded', (event) => console.debug(event));
   client.on('commandFailed', (event) => console.debug(event));

--- a/source/fundamentals/logging.txt
+++ b/source/fundamentals/logging.txt
@@ -14,7 +14,10 @@ Logging
 
   The driver doesn't use the logger in this version. Attempting to use
   prior settings in this version won't print anything. Instead, see our
-  :doc:`command monitoring guide <monitoring/command-monitoring>`. 
+  monitoring guides:
+
+  - :doc:`Command Monitoring </fundamentals/monitoring/command-monitoring>` 
+  - :doc:`Cluster Monitoring </fundamentals/monitoring/cluster-monitoring>`. 
 
 Temporary Alternative
 ---------------------

--- a/source/fundamentals/logging.txt
+++ b/source/fundamentals/logging.txt
@@ -17,7 +17,7 @@ Logging
   monitoring guides:
 
   - :doc:`Command Monitoring </fundamentals/monitoring/command-monitoring>` 
-  - :doc:`Cluster Monitoring </fundamentals/monitoring/cluster-monitoring>`. 
+  - :doc:`Cluster Monitoring </fundamentals/monitoring/cluster-monitoring>`
 
 Temporary Alternative
 ---------------------


### PR DESCRIPTION
## Pull Request Info

Fixed the command monitoring link and added cluster monitoring 

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-17837

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-17837-linkFix/fundamentals/logging/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?
