### PR TITLE
DOCSP-18066: fixed example for DeleteOne

### DIFF
--- a/source/code-snippets/usage-examples/deleteOne.js
+++ b/source/code-snippets/usage-examples/deleteOne.js
@@ -13,12 +13,12 @@ async function run() {
     const database = client.db("sample_mflix");
     const movies = database.collection("movies");
 
-    // Query for a movie that has a title of type string
-    const query = { title: { $type: "string" } };
+    // Query for a movie that has title "Annie Hall"
+    const query = { title: "Annie Hall" };
 
     const result = await movies.deleteOne(query);
     if (result.deletedCount === 1) {
-      console.dir("Successfully deleted one document.");
+      console.log("Successfully deleted one document.");
     } else {
       console.log("No documents matched the query. Deleted 0 documents.");
     }

--- a/source/usage-examples/deleteOne.txt
+++ b/source/usage-examples/deleteOne.txt
@@ -41,7 +41,7 @@ Example
 
 The following snippet deletes a single document from the ``movies``
 collection. It uses a **query document** that configures the query
-to match only movies with a title of type ``string``.
+to match movies with a ``title`` value of "Annie Hall".
 
 .. include:: /includes/connect-guide-note.rst
 
@@ -71,4 +71,4 @@ If you run the example above, you should see output that resembles the following
 .. code-block:: none
    :copyable: false
 
-   'Successfully deleted one document.'
+   Successfully deleted one document.

--- a/source/usage-examples/deleteOne.txt
+++ b/source/usage-examples/deleteOne.txt
@@ -66,9 +66,18 @@ to match movies with a ``title`` value of "Annie Hall".
    The JavaScript and TypeScript code snippets above are identical. There are no
    TypeScript specific features of the driver relevant to this use case.
 
-If you run the example above, you should see output that resembles the following:
+If you run the example, you should see output that resembles the following:
 
 .. code-block:: none
    :copyable: false
 
    Successfully deleted one document.
+
+Because you already deleted the matched document for the query filter,
+if you attempt to run the example again you should see output that resembles
+the following:
+
+.. code-block:: none
+   :copyable: false
+
+   No documents matched the query. Deleted 0 documents.


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-18066

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-18066-deleteone-fix/usage-examples/deleteOne/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?
