### PR TITLE
DOCSP-17991 4.0-Code-Snippets

### DIFF
--- a/source/fundamentals/crud/read-operations/limit.txt
+++ b/source/fundamentals/crud/read-operations/limit.txt
@@ -30,7 +30,7 @@ a collection and return only certain results from a query using a sort,
 a skip, and a limit. Consider the following collection of documents that
 describe books:
 
-.. code-block:: javascript
+.. code-block:: json
 
    [
      { "_id": 1, "name": "The Brothers Karamazov", "author": "Dostoyevsky", "length": 824 },
@@ -65,7 +65,8 @@ books, and applies a ``limit`` to return only ``3`` results:
 The code example above outputs the following three documents, sorted by
 length:
 
-.. code-block:: javascript
+.. code-block:: json
+   :copyable: false
 
    { "_id": 2, "title": "Les Misérables", "author": "Hugo", "length": 1462 }
    { "_id": 6, "title": "A Dance With Dragons", "author": "Martin", "length": 1104 }
@@ -116,7 +117,8 @@ passing the number of documents to bypass as shown below:
 This operation returns the documents that describe the fourth through sixth
 books in order of longest-to-shortest length:
 
-.. code-block:: javascript
+.. code-block:: json
+   :copyable: false
 
    { "_id": 3, "title": "Atlas Shrugged", "author": "Rand", "length": 1088 }
    { "_id": 5, "title": "Cryptonomicon", "author": "Stephenson", "length": 918 }

--- a/source/fundamentals/crud/read-operations/project.txt
+++ b/source/fundamentals/crud/read-operations/project.txt
@@ -34,7 +34,7 @@ Sample Documents
 Consider the following collection containing documents that describe
 varieties of fruit:
 
-.. code-block:: javascript
+.. code-block:: json
 
    [
      { "_id": 1, "name": "apples", "qty": 5, "rating": 3 },
@@ -66,7 +66,8 @@ excludes the ``qty`` and ``rating`` fields. Passing this projection to
 ``find()`` with an empty query document and no sort document yields
 the following results:
 
-.. code-block:: javascript
+.. code-block:: json
+   :copyable: false
 
    { "_id": 1, "name": "apples" }
    { "_id": 2, "name": "bananas" }
@@ -103,7 +104,8 @@ excludes the ``qty`` and ``rating`` fields. Passing this projection to
 ``find()`` with an empty query document and no sort document yields
 the following results:
 
-.. code-block:: javascript
+.. code-block:: json
+   :copyable: false
 
    { "name": "apples" }
    { "name": "bananas" }
@@ -126,7 +128,8 @@ order in which they are returned.
 This example that identifies two fields to include in the projection yields
 the following results:
 
-.. code-block:: javascript
+.. code-block:: json
+   :copyable: false
 
      { "name": "apples", "rating": 3 }
      { "name": "bananas", "rating": 1 }

--- a/source/fundamentals/crud/read-operations/retrieve.txt
+++ b/source/fundamentals/crud/read-operations/retrieve.txt
@@ -80,6 +80,7 @@ matching document or ``null`` if there are no matches.
    The output might resemble the following:
 
    .. code-block:: none
+      :copyable: false
 
       [
         { name: "Lemony Snicket", type: "horseradish pizza", qty: 1, status: "delivered", date: ... },
@@ -123,6 +124,7 @@ group, and arrange the result data from a collection.
    The output might resemble the following:
 
    .. code-block:: none
+      :copyable: false
 
       [
         { _id: 'delivering', count: 5 },

--- a/source/fundamentals/crud/read-operations/skip.txt
+++ b/source/fundamentals/crud/read-operations/skip.txt
@@ -33,7 +33,7 @@ a collection and perform a sort and skip on the results of a query.
 Consider a collection containing documents that describe varieties of
 fruit:
 
-.. code-block:: javascript
+.. code-block:: json
 
    [
       { "_id": 1, "name": "apples", "qty": 5, "rating": 3 },
@@ -72,7 +72,8 @@ Since we specified that the first ``2`` documents should be skipped, the
 third and fourth highest rating documents are printed by the code snippet
 above:
 
-.. code-block:: javascript
+.. code-block:: json
+   :copyable: false
 
    { "_id": 3, "name": "oranges", "qty": 6, "rating": 2 }
    { "_id": 2, "name": "bananas", "qty": 7, "rating": 1 }

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -63,7 +63,8 @@ In this case, the number ``-1`` tells the read operation to sort the
 books in descending order by length. ``find()`` returns the following
 documents when this sort is used with an empty query:
 
-.. code-block:: javascript
+.. code-block:: json
+   :copyable: false
 
    { "_id": 2, "title": "Les Misérables", "author": "Hugo", "length": 1462 }
    { "_id": 4, "title": "Infinite Jest", "author": "Wallace", "length": 1104 }
@@ -96,7 +97,8 @@ returns the following ordering of documents when this sort is used on
 the documents matching the query, sorting "Martin" before "Wallace" for
 the two books with the same length:
 
-.. code-block:: javascript
+.. code-block:: json
+   :copyable: false
 
    { "_id": 1, "title": "The Brothers Karamazov", "author": "Dostoyevsky", "length": 824 }
    { "_id": 5, "title": "Cryptonomicon", "author": "Stephenson", "length": 918 }

--- a/source/fundamentals/crud/read-operations/text.txt
+++ b/source/fundamentals/crud/read-operations/text.txt
@@ -66,7 +66,8 @@ the search terms (logical ``OR``).
 
 This operation returns the following documents:
 
-.. code-block:: javascript
+.. code-block:: json
+   :copyable: false
 
    { title: 'Trek Nation' }
    { title: 'Star Trek' }
@@ -103,7 +104,8 @@ multi-word phrase with escaped quotes (``\"<term>\"``):
 Querying by the phrase "star trek" instead of just the term "trek"
 matches the following documents:
 
-.. code-block:: javascript
+.. code-block:: json
+   :copyable: false
 
    { title: 'Star Trek' }
    { title: 'Star Trek Into Darkness' }
@@ -139,7 +141,8 @@ includes two distinct terms, separate them with a space.
 
 Querying with the negated term yields the following documents:
 
-.. code-block:: javascript
+.. code-block:: json
+   :copyable: false
 
    { title: 'Star Trek' }
    { title: 'Star Trek: Nemesis' }
@@ -172,7 +175,8 @@ Querying in this way returns the following documents in the following
 order. In general, text relevance increases as a string matches more
 terms and decreases as the unmatched portion of the string lengthens.
 
-.. code-block:: javascript
+.. code-block:: json
+   :copyable: false
 
    { title: 'Star Trek', score: 1.5 }
    { title: 'Star Trek: Generations', score: 1.3333333333333333 }

--- a/source/fundamentals/crud/write-operations/change-a-document.txt
+++ b/source/fundamentals/crud/write-operations/change-a-document.txt
@@ -29,7 +29,7 @@ document** that specifies the **update operator** (the type of update to
 perform) and the fields and values that describe the change. Update
 documents use the following format:
 
-.. code-block:: javascript
+.. code-block:: json
 
    {
       <update operator>: {
@@ -74,7 +74,7 @@ Example
 Consider a document of fields containing the English alphabet of lowercase
 letters ``a`` through ``z`` and their ordinal values:
 
-.. code-block:: javascript
+.. code-block:: json
 
    {
       _id: 465,
@@ -103,7 +103,8 @@ your update operation might resemble the following:
 The updated document resembles the following, with an an updated value in
 the ``z`` field and all other values unchanged:
 
-.. code-block:: javascript
+.. code-block:: json
+   :copyable: false
 
    {
       _id: 465,
@@ -132,7 +133,7 @@ To perform a replacement operation, create a **replacement document** that
 consists of the fields and values that you would like to insert in your
 **replace** operation. Replacement documents use the following format:
 
-.. code-block:: javascript
+.. code-block:: json
 
    {
       <field>: {
@@ -152,7 +153,7 @@ Example
 Consider a document of fields containing the English alphabet of lowercase
 letters ``a`` through ``z`` and their ordinal values:
 
-.. code-block:: javascript
+.. code-block:: json
 
    {
       _id: 465,
@@ -180,7 +181,8 @@ resemble the following:
 The replaced document contains the contents of the replacement document
 and the immutable ``_id`` field as follows:
 
-.. code-block:: javascript
+.. code-block:: json
+   :copyable: false
 
    {
       _id: 465,

--- a/source/fundamentals/crud/write-operations/embedded-arrays.txt
+++ b/source/fundamentals/crud/write-operations/embedded-arrays.txt
@@ -136,6 +136,7 @@ omit the ``items.type`` field from the query and specify the ``$`` operator
 in our update, we encounter the following error:
 
 .. code-block:: none
+   :copyable: false
 
    The positional operator did not find the match needed from the query.
 
@@ -165,7 +166,8 @@ order items.
 After you run the update method, your customer document for "Popeye" should
 resemble the following:
 
-.. code-block:: javascript
+.. code-block:: json
+   :copyable: false
 
    {
      "name":"Popeye",
@@ -245,7 +247,8 @@ The following snippet shows the complete update method for this example:
 After we run the method above, all of the large pizza order items for
 customer "Steve Lobsters" now contain "garlic" in the ``toppings`` field:
 
-.. code-block:: javascript
+.. code-block:: json
+   :copyable: false
 
    {
      name: "Steve Lobsters",
@@ -275,7 +278,8 @@ the update as follows:
 
 After we run the update method, the document resembles the following:
 
-.. code-block:: javascript
+.. code-block:: json
+   :copyable: false
 
    {
      name: "Steve Lobsters",

--- a/source/fundamentals/indexes.txt
+++ b/source/fundamentals/indexes.txt
@@ -198,7 +198,8 @@ The ``location.geo`` field in following sample document from the
 ``theaters`` collection in the ``sample_mflix`` database is a GeoJSON Point
 object that describes the coordinates of the theater:
 
-.. code-block:: javascript
+.. code-block:: json
+   :copyable: false
 
    {
       "_id" : ObjectId("59a47286cfa9a3a73e51e75c"),
@@ -258,6 +259,7 @@ that violates the unique index, MongoDB will throw an error that resembles
 the following:
 
 .. code-block:: none
+   :copyable: false
 
    E11000 duplicate key error index
 

--- a/source/fundamentals/monitoring/cluster-monitoring.txt
+++ b/source/fundamentals/monitoring/cluster-monitoring.txt
@@ -85,7 +85,8 @@ The following sections show sample output for each type of SDAM event.
 serverDescriptionChanged
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block:: js
+.. code-block:: json
+   :copyable: false
 
   ServerDescriptionChangedEvent {
      topologyId: 0,
@@ -166,7 +167,8 @@ one of the following possible values:
 serverHeartbeatStarted
 ^^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block:: js
+.. code-block:: json
+   :copyable: false
 
    ServerHeartbeatStartedEvent {
      connectionId: 'localhost:27017'
@@ -175,7 +177,8 @@ serverHeartbeatStarted
 serverHeartbeatSucceeded
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block:: js
+.. code-block:: json
+   :copyable: false
 
    ServerHeartbeatSucceededEvent {
      duration: 1.939997,
@@ -212,7 +215,8 @@ serverHeartbeatSucceeded
 serverHeartbeatFailed
 ^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block:: js
+.. code-block:: json
+   :copyable: false
 
    ServerHeartbeatFailed {
      duration: 20,
@@ -223,7 +227,8 @@ serverHeartbeatFailed
 serverOpening
 ^^^^^^^^^^^^^
 
-.. code-block:: js
+.. code-block:: json
+   :copyable: false
 
    ServerOpeningEvent {
      topologyId: 0,
@@ -233,7 +238,8 @@ serverOpening
 serverClosed
 ^^^^^^^^^^^^
 
-.. code-block:: js
+.. code-block:: json
+   :copyable: false
 
    ServerClosedEvent {
      topologyId: 0,
@@ -243,7 +249,8 @@ serverClosed
 topologyOpening
 ^^^^^^^^^^^^^^^
 
-.. code-block:: js
+.. code-block:: json
+   :copyable: false
 
    TopologyOpeningEvent {
      topologyId: 0
@@ -252,7 +259,8 @@ topologyOpening
 topologyClosed
 ^^^^^^^^^^^^^^
 
-.. code-block:: js
+.. code-block:: json
+   :copyable: false
 
    TopologyClosedEvent {
      topologyId: 0
@@ -261,7 +269,8 @@ topologyClosed
 topologyDescriptionChanged
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block:: js
+.. code-block:: json
+   :copyable: false
 
    TopologyDescriptionChangedEvent {
      topologyId: 0,

--- a/source/fundamentals/monitoring/command-monitoring.txt
+++ b/source/fundamentals/monitoring/command-monitoring.txt
@@ -59,7 +59,8 @@ The following sections show sample output for each type of command monitoring ev
 commandStarted
 ^^^^^^^^^^^^^^
 
-.. code-block:: js
+.. code-block:: json
+   :copyable: false
 
   CommandStartedEvent {
     requestId: 1534,
@@ -75,7 +76,8 @@ commandStarted
 commandSucceeded
 ^^^^^^^^^^^^^^^^
 
-.. code-block:: js
+.. code-block:: json
+   :copyable: false
 
   CommandSucceededEvent {
     requestId: 1534,
@@ -104,7 +106,8 @@ commandSucceeded
 commandFailed
 ^^^^^^^^^^^^^
 
-.. code-block:: js
+.. code-block:: json
+   :copyable: false
 
   CommandFailedEvent {
     requestId: 1534,

--- a/source/usage-examples/bulkWrite.txt
+++ b/source/usage-examples/bulkWrite.txt
@@ -76,7 +76,8 @@ to ``bulkWrite()`` includes examples of ``insertOne``, ``updateMany``, and
 
 When you run the code sample, your output should resemble the following:
 
-.. code-block:: javascript
+.. code-block:: json
+   :copyable: false
 
    BulkWriteResult {
      result: {

--- a/source/usage-examples/changeStream.txt
+++ b/source/usage-examples/changeStream.txt
@@ -130,7 +130,8 @@ callback process the event before exiting.
 If you run the example above, you should see output similar to the
 following:
 
-.. code-block:: javascript
+.. code-block:: json
+   :copyable: false
 
    received a change to the collection: 	 {
      _id: {

--- a/source/usage-examples/command.txt
+++ b/source/usage-examples/command.txt
@@ -58,7 +58,8 @@ Example
 When you run the above command, you should see output similar to the
 following:
 
-.. code-block:: javascript
+.. code-block:: json
+   :copyable: false
 
    {
      db: 'sample_mflix',

--- a/source/usage-examples/count.txt
+++ b/source/usage-examples/count.txt
@@ -78,5 +78,3 @@ following:
 
    Estimated number of documents in the movies collection: 23541
    Number of movies from Canada: 1349
-
-

--- a/source/usage-examples/deleteMany.txt
+++ b/source/usage-examples/deleteMany.txt
@@ -57,6 +57,7 @@ The first time you run the preceding example, you should see output that
 resembles the following:
 
 .. code-block:: none
+   :copyable: false
 
    Deleted 19 documents
 
@@ -64,5 +65,6 @@ On subsequent runs of the example, as you already deleted all relevant
 documents, you should see output that resembles the following:
 
 .. code-block:: none
+   :copyable: false
 
    Deleted 0 documents

--- a/source/usage-examples/find.txt
+++ b/source/usage-examples/find.txt
@@ -70,7 +70,8 @@ uses the following parameters:
 If you run the example above, you should see results that resemble the
 following:
 
-.. code-block:: javascript
+.. code-block:: json
+   :copyable: false
 
    { title: '10 Minutes', imdb: { rating: 7.9, votes: 743, id: 339976 } }
    { title: '3x3', imdb: { rating: 6.9, votes: 206, id: 1654725 } }

--- a/source/usage-examples/findOne.txt
+++ b/source/usage-examples/findOne.txt
@@ -66,7 +66,8 @@ collection. It uses the following parameters:
 If you run the example above, you should see a result that resembles the
 following:
 
-.. code-block:: javascript
+.. code-block:: json
+   :copyable: false
 
    { title: 'The Room', imdb: { rating: 3.5, votes: 25673, id: 368226 } }
 

--- a/source/usage-examples/insertMany.txt
+++ b/source/usage-examples/insertMany.txt
@@ -49,5 +49,6 @@ Example
 If you run the example above, you should see output that resembles the following:
 
 .. code-block:: none
+   :copyable: false
    
    3 documents were inserted

--- a/source/usage-examples/insertOne.txt
+++ b/source/usage-examples/insertOne.txt
@@ -25,11 +25,8 @@ can also pass a callback method as an optional third parameter.
 For more information on this method, see the
 :node-api-4.0:`insertOne() API documentation </classes/collection.html#insertone>`.
 
-The ``insertedId`` field of this object is the ``_id`` of the
-inserted document. If the operation fails to create a document, the
-``insertedCount`` field of this object has a value of ``0``. If the
-operation creates a document, the ``insertedCount`` field of this object
-has a value of ``1``.
+If the operation creates a document, the ``insertedId`` field of this
+object is the ``_id`` of the inserted document. 
 
 Example
 -------
@@ -55,6 +52,6 @@ Example
 If you run the example above, you should see output that resembles the following:
 
 .. code-block:: none
+   :copyable: false
 
    A document was inserted with the _id: <your _id value>
-

--- a/source/usage-examples/replaceOne.txt
+++ b/source/usage-examples/replaceOne.txt
@@ -63,5 +63,6 @@ If you run the preceding example, you should see output that resembles the
 following:
 
 .. code-block:: none
+   :copyable: false
 
    Modified 1 document(s)

--- a/source/usage-examples/updateMany.txt
+++ b/source/usage-examples/updateMany.txt
@@ -49,5 +49,7 @@ Example
 If you run the example above, you should see output like this:
 
 .. code-block:: none
+   :copyable: false
 
    Updated 477 documents
+   


### PR DESCRIPTION
## Pull Request Info

- Tested all code snippets. No changes were needed, but I removed information about the insertCount for insertOne since it's not longer a property.
- Made all output not copyable.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-17991

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/4.0-Code-Snippets/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?
