### PR TITLE
DOCSP-17991 code-block fixes

### DIFF
--- a/source/fundamentals/crud/read-operations/limit.txt
+++ b/source/fundamentals/crud/read-operations/limit.txt
@@ -30,7 +30,7 @@ a collection and return only certain results from a query using a sort,
 a skip, and a limit. Consider the following collection of documents that
 describe books:
 
-.. code-block:: javascript
+.. code-block:: json
 
    [
      { "_id": 1, "name": "The Brothers Karamazov", "author": "Dostoyevsky", "length": 824 },
@@ -65,7 +65,8 @@ books, and applies a ``limit`` to return only ``3`` results:
 The code example above outputs the following three documents, sorted by
 length:
 
-.. code-block:: javascript
+.. code-block:: json
+   :copyable: false
 
    { "_id": 2, "title": "Les Misérables", "author": "Hugo", "length": 1462 }
    { "_id": 6, "title": "A Dance With Dragons", "author": "Martin", "length": 1104 }
@@ -116,8 +117,9 @@ passing the number of documents to bypass as shown below:
 This operation returns the documents that describe the fourth through sixth
 books in order of longest-to-shortest length:
 
-.. code-block:: javascript
-
+.. code-block:: json
+   :copyable: false
+   
    { "_id": 3, "title": "Atlas Shrugged", "author": "Rand", "length": 1088 }
    { "_id": 5, "title": "Cryptonomicon", "author": "Stephenson", "length": 918 }
    { "_id": 1, "title": "The Brothers Karamazov", "author": "Dostoyevsky", "length": 824 }

--- a/source/fundamentals/crud/read-operations/project.txt
+++ b/source/fundamentals/crud/read-operations/project.txt
@@ -34,7 +34,7 @@ Sample Documents
 Consider the following collection containing documents that describe
 varieties of fruit:
 
-.. code-block:: javascript
+.. code-block:: json
 
    [
      { "_id": 1, "name": "apples", "qty": 5, "rating": 3 },
@@ -66,7 +66,8 @@ excludes the ``qty`` and ``rating`` fields. Passing this projection to
 ``find()`` with an empty query document and no sort document yields
 the following results:
 
-.. code-block:: javascript
+.. code-block:: json
+   :copyable: false
 
    { "_id": 1, "name": "apples" }
    { "_id": 2, "name": "bananas" }
@@ -103,7 +104,8 @@ excludes the ``qty`` and ``rating`` fields. Passing this projection to
 ``find()`` with an empty query document and no sort document yields
 the following results:
 
-.. code-block:: javascript
+.. code-block:: json
+   :copyable: false
 
    { "name": "apples" }
    { "name": "bananas" }
@@ -126,7 +128,8 @@ order in which they are returned.
 This example that identifies two fields to include in the projection yields
 the following results:
 
-.. code-block:: javascript
+.. code-block:: json
+   :copyable: false
 
      { "name": "apples", "rating": 3 }
      { "name": "bananas", "rating": 1 }

--- a/source/fundamentals/crud/read-operations/retrieve.txt
+++ b/source/fundamentals/crud/read-operations/retrieve.txt
@@ -79,7 +79,8 @@ matching document or ``null`` if there are no matches.
 
    The output might resemble the following:
 
-   .. code-block:: none
+   .. code-block:: javascript
+      :copyable: false
 
       [
         { name: "Lemony Snicket", type: "horseradish pizza", qty: 1, status: "delivered", date: ... },
@@ -122,12 +123,13 @@ group, and arrange the result data from a collection.
 
    The output might resemble the following:
 
-   .. code-block:: none
+   .. code-block:: javascript
+      :copyable: false
 
       [
         { _id: 'delivering', count: 5 },
         { _id: 'delivered', count: 37 },
-        { _id: 'created', count: 9 },
+        { _id: 'created', count: 9 }
       ]
 
 See the MongoDB server manual pages on :manual:`aggregation </aggregation>`

--- a/source/fundamentals/crud/read-operations/skip.txt
+++ b/source/fundamentals/crud/read-operations/skip.txt
@@ -33,7 +33,7 @@ a collection and perform a sort and skip on the results of a query.
 Consider a collection containing documents that describe varieties of
 fruit:
 
-.. code-block:: javascript
+.. code-block:: json
 
    [
       { "_id": 1, "name": "apples", "qty": 5, "rating": 3 },
@@ -72,7 +72,8 @@ Since we specified that the first ``2`` documents should be skipped, the
 third and fourth highest rating documents are printed by the code snippet
 above:
 
-.. code-block:: javascript
+.. code-block:: json
+   :copyable: false
 
    { "_id": 3, "name": "oranges", "qty": 6, "rating": 2 }
    { "_id": 2, "name": "bananas", "qty": 7, "rating": 1 }

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -63,7 +63,8 @@ In this case, the number ``-1`` tells the read operation to sort the
 books in descending order by length. ``find()`` returns the following
 documents when this sort is used with an empty query:
 
-.. code-block:: javascript
+.. code-block:: json
+   :copyable: false
 
    { "_id": 2, "title": "Les Misérables", "author": "Hugo", "length": 1462 }
    { "_id": 4, "title": "Infinite Jest", "author": "Wallace", "length": 1104 }
@@ -96,7 +97,8 @@ returns the following ordering of documents when this sort is used on
 the documents matching the query, sorting "Martin" before "Wallace" for
 the two books with the same length:
 
-.. code-block:: javascript
+.. code-block:: json
+   :copyable: false
 
    { "_id": 1, "title": "The Brothers Karamazov", "author": "Dostoyevsky", "length": 824 }
    { "_id": 5, "title": "Cryptonomicon", "author": "Stephenson", "length": 918 }

--- a/source/fundamentals/crud/read-operations/text.txt
+++ b/source/fundamentals/crud/read-operations/text.txt
@@ -67,6 +67,7 @@ the search terms (logical ``OR``).
 This operation returns the following documents:
 
 .. code-block:: javascript
+   :copyable: false
 
    { title: 'Trek Nation' }
    { title: 'Star Trek' }
@@ -104,6 +105,7 @@ Querying by the phrase "star trek" instead of just the term "trek"
 matches the following documents:
 
 .. code-block:: javascript
+   :copyable: false
 
    { title: 'Star Trek' }
    { title: 'Star Trek Into Darkness' }
@@ -140,6 +142,7 @@ includes two distinct terms, separate them with a space.
 Querying with the negated term yields the following documents:
 
 .. code-block:: javascript
+   :copyable: false
 
    { title: 'Star Trek' }
    { title: 'Star Trek: Nemesis' }
@@ -173,7 +176,8 @@ order. In general, text relevance increases as a string matches more
 terms and decreases as the unmatched portion of the string lengthens.
 
 .. code-block:: javascript
-
+   :copyable: false
+   
    { title: 'Star Trek', score: 1.5 }
    { title: 'Star Trek: Generations', score: 1.3333333333333333 }
    { title: 'Star Trek: Insurrection', score: 1.3333333333333333 }

--- a/source/fundamentals/crud/write-operations/change-a-document.txt
+++ b/source/fundamentals/crud/write-operations/change-a-document.txt
@@ -95,6 +95,7 @@ The updated document resembles the following, with an an updated value in
 the ``z`` field and all other values unchanged:
 
 .. code-block:: javascript
+   :copyable: false
 
    {
       _id: 465,
@@ -172,6 +173,7 @@ The replaced document contains the contents of the replacement document
 and the immutable ``_id`` field as follows:
 
 .. code-block:: javascript
+   :copyable: false
 
    {
       _id: 465,

--- a/source/fundamentals/crud/write-operations/embedded-arrays.txt
+++ b/source/fundamentals/crud/write-operations/embedded-arrays.txt
@@ -136,6 +136,7 @@ omit the ``items.type`` field from the query and specify the ``$`` operator
 in our update, we encounter the following error:
 
 .. code-block:: none
+   :copyable: false
 
    The positional operator did not find the match needed from the query.
 
@@ -165,8 +166,9 @@ order items.
 After you run the update method, your customer document for "Popeye" should
 resemble the following:
 
-.. code-block:: javascript
-
+.. code-block:: json
+   :copyable: false
+   
    {
      "name":"Popeye",
      ...
@@ -246,6 +248,7 @@ After we run the method above, all of the large pizza order items for
 customer "Steve Lobsters" now contain "garlic" in the ``toppings`` field:
 
 .. code-block:: javascript
+   :copyable: false
 
    {
      name: "Steve Lobsters",
@@ -276,6 +279,7 @@ the update as follows:
 After we run the update method, the document resembles the following:
 
 .. code-block:: javascript
+   :copyable: false
 
    {
      name: "Steve Lobsters",

--- a/source/fundamentals/indexes.txt
+++ b/source/fundamentals/indexes.txt
@@ -198,7 +198,8 @@ The ``location.geo`` field in following sample document from the
 ``theaters`` collection in the ``sample_mflix`` database is a GeoJSON Point
 object that describes the coordinates of the theater:
 
-.. code-block:: javascript
+.. code-block:: json
+   :copyable: false
 
    {
       "_id" : ObjectId("59a47286cfa9a3a73e51e75c"),
@@ -258,7 +259,8 @@ that violates the unique index, MongoDB will throw an error that resembles
 the following:
 
 .. code-block:: none
-
+   :copyable: false
+   
    E11000 duplicate key error index
 
 Refer to the :manual:`Unique Indexes page </core/index-unique>` in the

--- a/source/fundamentals/monitoring.txt
+++ b/source/fundamentals/monitoring.txt
@@ -85,9 +85,10 @@ The following sections show sample output for each type of SDAM event.
 ``serverDescriptionChanged``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block:: js
+.. code-block:: javascript
+   :copyable: false
 
-  ServerDescriptionChangedEvent {
+   ServerDescriptionChangedEvent {
      topologyId: 0,
      address: 'localhost:27017',
      previousDescription: ServerDescription {
@@ -166,7 +167,8 @@ one of the following possible values:
 serverHeartbeatStarted
 ^^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block:: js
+.. code-block:: javascript
+   :copyable: false
 
    ServerHeartbeatStartedEvent {
      connectionId: 'localhost:27017'
@@ -175,7 +177,8 @@ serverHeartbeatStarted
 serverHeartbeatSucceeded
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block:: js
+.. code-block:: javascript
+   :copyable: false
 
    ServerHeartbeatSucceededEvent {
      duration: 1.939997,
@@ -212,7 +215,8 @@ serverHeartbeatSucceeded
 serverHeartbeatFailed
 ^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block:: js
+.. code-block:: javascript
+   :copyable: false
 
    ServerHeartbeatFailed {
      duration: 20,
@@ -223,7 +227,8 @@ serverHeartbeatFailed
 serverOpening
 ^^^^^^^^^^^^^
 
-.. code-block:: js
+.. code-block:: javascript
+   :copyable: false
 
    ServerOpeningEvent {
      topologyId: 0,
@@ -233,7 +238,8 @@ serverOpening
 serverClosed
 ^^^^^^^^^^^^
 
-.. code-block:: js
+.. code-block:: javascript
+   :copyable: false
 
    ServerClosedEvent {
      topologyId: 0,
@@ -243,7 +249,8 @@ serverClosed
 topologyOpening
 ^^^^^^^^^^^^^^^
 
-.. code-block:: js
+.. code-block:: javascript
+   :copyable: false
 
    TopologyOpeningEvent {
      topologyId: 0
@@ -252,7 +259,8 @@ topologyOpening
 topologyClosed
 ^^^^^^^^^^^^^^
 
-.. code-block:: js
+.. code-block:: javascript
+   :copyable: false
 
    TopologyClosedEvent {
      topologyId: 0
@@ -261,7 +269,8 @@ topologyClosed
 topologyDescriptionChanged
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block:: js
+.. code-block:: javascript
+   :copyable: false
 
    TopologyDescriptionChangedEvent {
      topologyId: 0,

--- a/source/usage-examples/bulkWrite.txt
+++ b/source/usage-examples/bulkWrite.txt
@@ -77,6 +77,7 @@ to ``bulkWrite()`` includes examples of ``insertOne``, ``updateMany``, and
 When you run the code sample, your output should resemble the following:
 
 .. code-block:: javascript
+   :copyable: false
 
    BulkWriteResult {
      result: {

--- a/source/usage-examples/changeStream.txt
+++ b/source/usage-examples/changeStream.txt
@@ -116,6 +116,7 @@ If you run the example above, you should see output similar to the
 following:
 
 .. code-block:: javascript
+   :copyable: false
 
    received a change to the collection: 	 {
      _id: {

--- a/source/usage-examples/command.txt
+++ b/source/usage-examples/command.txt
@@ -43,6 +43,7 @@ When you run the above command, you should see output similar to the
 following:
 
 .. code-block:: javascript
+   :copyable: false
 
    {
      db: 'sample_mflix',

--- a/source/usage-examples/count.txt
+++ b/source/usage-examples/count.txt
@@ -61,5 +61,3 @@ following:
 
    Estimated number of documents in the movies collection: 23541
    Number of movies from Canada: 1349
-
-

--- a/source/usage-examples/find.txt
+++ b/source/usage-examples/find.txt
@@ -57,6 +57,7 @@ If you run the example above, you should see results that resemble the
 following:
 
 .. code-block:: javascript
+   :copyable: false
 
    { title: '10 Minutes', imdb: { rating: 7.9, votes: 743, id: 339976 } }
    { title: '3x3', imdb: { rating: 6.9, votes: 206, id: 1654725 } }

--- a/source/usage-examples/findOne.txt
+++ b/source/usage-examples/findOne.txt
@@ -55,6 +55,7 @@ If you run the example above, you should see a result that resembles the
 following:
 
 .. code-block:: javascript
+   :copyable: false
 
    { title: 'The Room', imdb: { rating: 3.5, votes: 25673, id: 368226 } }
 


### PR DESCRIPTION
## Pull Request Info

Made code-blocks the correct language and outputs not copyable. 

Changes made reflect what was done for 4.0 and later: https://github.com/mongodb/docs-node/pull/243 

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-17991

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-17991-codeblockFixes/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?
