### PR TITLE
DOCSP-18482 api constants

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -4,6 +4,7 @@ title = "Node.js"
 toc_landing_pages = ["/fundamentals/authentication", "/fundamentals", "/fundamentals/crud", "/usage-examples"]
 
 [constants]
-version = 4.0
+version = 3.6
 package-name-org = "mongodb-org"
 pgp-version = "{+version+}"
+node-api = "http://mongodb.github.io/node-mongodb-native/{+version+}"

--- a/snooty.toml
+++ b/snooty.toml
@@ -4,7 +4,7 @@ title = "Node.js"
 toc_landing_pages = ["/fundamentals/authentication", "/fundamentals", "/fundamentals/crud", "/usage-examples"]
 
 [constants]
-version = 3.6
+version = 3.7
 package-name-org = "mongodb-org"
 pgp-version = "{+version+}"
-node-api = "http://mongodb.github.io/node-mongodb-native/{+version+}"
+node-api = "http://mongodb.github.io/node-mongodb-native/{+version+}/api"

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -29,7 +29,7 @@ What Is the Difference Between "connectTimeoutMS", "socketTimeoutMS" and "maxTim
 
        .. tip::
 
-          To modify the allowed time for :node-api-3.6:`MongoClient.connect <MongoClient.html#.connect>` to establish a
+          To modify the allowed time for `MongoClient.connect <{+node-api+}/MongoClient.html#.connect>`__ to establish a
           connection to a MongoDB server, use the ``serverSelectionTimeoutMS`` option instead.
 
        **Default:** 10000
@@ -39,7 +39,7 @@ What Is the Difference Between "connectTimeoutMS", "socketTimeoutMS" and "maxTim
        never time out the socket. This option applies only to sockets that
        have already been connected.
    * - maxTimeMS
-     - :node-api-3.6:`maxTimeMS <Cursor.html#maxTimeMS>` is the maximum
+     - `maxTimeMS <{+node-api+}/Cursor.html#maxTimeMS>`__ is the maximum
        amount of time the server should wait for an operation to complete
        after it has reached the server. If an operation runs over the
        specified time limit, it returns a timeout error.
@@ -56,7 +56,7 @@ follows:
    });
 
 To see all the available settings, see the
-:node-api-3.6:`MongoClientOptions <global.html#MongoClientOptions>` API
+`MongoClientOptions <{+node-api+}/global.html#MongoClientOptions>`__ API
 Documentation.  
 
 How Can I Prevent the Driver From Hanging During Connection or From Spending Too Long Trying to Reach Unreachable Replica Sets?

--- a/source/fundamentals/aggregation.txt
+++ b/source/fundamentals/aggregation.txt
@@ -107,7 +107,7 @@ This example should produce the following output:
    { _id: 3, count: 1 }
    { _id: 5, count: 1 }
    
-For more information, see the :node-api-3.6:`aggregate() API documentation <Collection.html#aggregate>`.
+For more information, see the `aggregate() API documentation <{+node-api+}/Collection.html#aggregate>`__.
 
 Additional Aggregation Examples
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/fundamentals/collations.txt
+++ b/source/fundamentals/collations.txt
@@ -284,7 +284,7 @@ contains the following documents:
 Aggregation Example
 ```````````````````
 
-To use collation with the :node-api-3.6:`aggregate <Collection.html#aggregate>`
+To use collation with the `aggregate <{+node-api+}/Collection.html#aggregate>`__
 operation, pass the collation document in the options field, after the
 array of pipeline stages.
 

--- a/source/fundamentals/connection.txt
+++ b/source/fundamentals/connection.txt
@@ -292,4 +292,4 @@ URI to specify the behavior of the client.
        :manual:`w Option </reference/write-concern/#w-option>`.
 
 For a complete list of options, see the `MongoClient
-<{+node-api+}/MongoClient.html>` API reference page.
+<{+node-api+}/MongoClient.html>`__ API reference page.

--- a/source/fundamentals/connection.txt
+++ b/source/fundamentals/connection.txt
@@ -291,36 +291,5 @@ URI to specify the behavior of the client.
        server documentation on the
        :manual:`w Option </reference/write-concern/#w-option>`.
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-For a complete list of options, see the :node-api-3.6:`MongoClient
-<MongoClient.html>` API reference page.
+For a complete list of options, see the `MongoClient
+<{+node-api+}/MongoClient.html>` API reference page.

--- a/source/fundamentals/crud/compound-operations.txt
+++ b/source/fundamentals/crud/compound-operations.txt
@@ -42,15 +42,15 @@ Built-in Methods
 
 There are three major compound operations:
 
-- :node-api-3.6:`findOneAndDelete() <Collection.html#findOneAndDelete>`
+- `findOneAndDelete() <{+node-api+}/Collection.html#findOneAndDelete>`__
   matches multiple documents to a supplied query and removes the first
   of those matched documents.
 
-- :node-api-3.6:`findOneAndUpdate() <Collection.html#findOneAndUpdate>`
+- `findOneAndUpdate() <{+node-api+}/Collection.html#findOneAndUpdate>`__
   matches multiple documents to a supplied query and updates the first
   of those matched documents using the provided update document.
 
-- :node-api-3.6:`findOneAndReplace() <Collection.html#findOneAndReplace>`
+- `findOneAndReplace() <{+node-api+}/Collection.html#findOneAndReplace>`__
   matches multiple documents to a supplied query and replaces the first
   of those matched documents using the provided replacement document.
 

--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -16,7 +16,7 @@ Overview
 Read operations that return multiple documents do not immediately return
 all values matching the query. Because a query can potentially match
 very large sets of documents, these operations rely upon an
-object called a :node-api-3.6:`cursor <Cursor.html>`
+object called a `cursor <{+node-api+}/Cursor.html>`__
 that fetches documents in batches to reduce both memory consumption and
 network bandwidth usage. Cursors are highly configurable and offer
 multiple interaction paradigms for different use cases.
@@ -72,8 +72,8 @@ pulling all matching documents into a collection in process memory.
 For Each Functional Iteration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can pass a function to the :node-api-3.6:`forEach()
-<Cursor.html#forEach>` method of any cursor to iterate through
+You can pass a function to the `forEach()
+<{+node-api+}/Cursor.html#forEach>`__ method of any cursor to iterate through
 results in a functional style:
 
 .. literalinclude:: /code-snippets/crud/cursor.js
@@ -85,10 +85,10 @@ Return an Array of All Documents
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For use cases that require all documents matched by a query to be held
-in memory at the same time, use :node-api-3.6:`toArray() </classes/findcursor.html#toarray>`. 
+in memory at the same time, use `toArray() <{+node-api+}/classes/findcursor.html#toarray>`__. 
 Note that large numbers of matched documents can cause performance issues
 or failures if the operation exceeds memory constraints. Consider using
-:node-api-3.6:`forEach() </classes/findcursor.html#foreach>` to iterate
+`forEach() <{+node-api+}/classes/findcursor.html#foreach>`__ to iterate
 through results unless you want to return all documents at once. 
 
 .. literalinclude:: /code-snippets/crud/cursor.js
@@ -111,9 +111,9 @@ allows you to use cursors in ``for``...``await`` loops:
 Manual Iteration
 ~~~~~~~~~~~~~~~~
 
-You can use the :node-api-3.6:`hasNext() <Cursor.html#hasNext>`
+You can use the `hasNext() <{+node-api+}/Cursor.html#hasNext>`__
 method to check if a cursor can provide additional data, and then use
-the :node-api-3.6:`next() <Cursor.html#next>`
+the `next() <{+node-api+}/Cursor.html#next>`__
 method to retrieve the subsequent element of the cursor:
 
 .. literalinclude:: /code-snippets/crud/cursor.js
@@ -151,7 +151,7 @@ Count
 ~~~~~
 
 For an estimated count of the number of documents referenced by the
-cursor, use :node-api-3.6:`count() <Cursor.html#count>`:
+cursor, use `count() <{+node-api+}/Cursor.html#count>`__:
 
 .. literalinclude:: /code-snippets/crud/cursor.js
    :language: javascript
@@ -162,7 +162,7 @@ Rewind
 ~~~~~~
 
 To reset a cursor to its initial position in the set of returned
-documents, use :node-api-3.6:`rewind() <Cursor.html#rewind>`.
+documents, use `rewind() <{+node-api+}/Cursor.html#rewind>`__.
 
 .. literalinclude:: /code-snippets/crud/cursor.js
    :language: javascript
@@ -174,7 +174,7 @@ Close
 
 Cursors consume memory and network resources both in the client
 application and in the connected instance of MongoDB. Use
-:node-api-3.6:`close() <Cursor.html#close>`
+`close() <{+node-api+}/Cursor.html#close>`__
 to free up a cursor's resources in both the client application
 and the MongoDB server:
 

--- a/source/fundamentals/crud/read-operations/limit.txt
+++ b/source/fundamentals/crud/read-operations/limit.txt
@@ -94,7 +94,7 @@ calls are equivalent:
 
 For more information on the ``options`` settings for the ``find()``
 method, see the
-:node-api-3.6:`API documentation on find() <Collection.html#find>`.
+`API documentation on find() <{+node-api+}/Collection.html#find>`__.
 
 Skip
 ----

--- a/source/fundamentals/crud/write-operations/insert.txt
+++ b/source/fundamentals/crud/write-operations/insert.txt
@@ -84,8 +84,8 @@ Your output should look something like this:
 For additional information on the classes and methods mentioned in this
 section, see the following resources: 
 
-- API Documentation on :node-api-3.6:`insertOne() <Collection.html#insertOne>` 
-- API Documentation on :node-api-3.6:`insertOneWriteOpResultObject <Collection.html#~insertOneWriteOpResult>`
+- API Documentation on `insertOne() <{+node-api+}/Collection.html#insertOne>`__
+- API Documentation on `insertOneWriteOpResultObject <{+node-api+}/Collection.html#~insertOneWriteOpResult>`__
 - Server Manual Entry on :manual:`insertOne() </reference/method/db.collection.insertOne/>`
 - Runnable :doc:`Insert a Document Example </usage-examples/insertOne>`
 
@@ -202,7 +202,7 @@ Your output should look something like this:
 For additional information on the classes and methods mentioned in this
 section, see the following resources: 
 
-- API Documentation on :node-api-3.6:`insertMany() <Collection.html#insertMany>`
-- API Documentation on :node-api-3.6:`insertWriteOpResult <Collection.html#~insertWriteOpResult>`
+- API Documentation on `insertMany() <{+node-api+}/Collection.html#insertMany>`__
+- API Documentation on `insertWriteOpResult <{+node-api+}/Collection.html#~insertWriteOpResult>`__
 - Server Manual Entry on :manual:`insertMany() </reference/method/db.collection.insertMany/>`
 - Runnable :doc:`Insert Multiple Documents Example </usage-examples/insertMany>`

--- a/source/fundamentals/gridfs.txt
+++ b/source/fundamentals/gridfs.txt
@@ -94,7 +94,7 @@ default name ``fs``, as shown in the following example:
 
    const bucket = new mongodb.GridFSBucket(db, { bucketName: 'myCustomBucket' });
 
-For more information, see the :node-api-3.6:`GridFSBucket API documentation <GridFSBucket.html>`.
+For more information, see the `GridFSBucket API documentation <{+node-api+}/GridFSBucket.html>`__.
 
 .. _gridfs-upload-files:
 
@@ -117,7 +117,7 @@ following code snippet:
             metadata: { field: 'myField', value: 'myValue' }
         });
 
-See the :node-api-3.6:`openUploadStream() API documentation <GridFSBucket.html#openUploadStream>` for more information.
+See the `openUploadStream() API documentation <{+node-api+}/GridFSBucket.html#openUploadStream>`__ for more information.
 
 .. _gridfs-retrieve-file-info:
 
@@ -154,8 +154,8 @@ combined with other methods such as ``sort()``, ``limit()``, and ``project()``.
 For more information on the classes and methods mentioned in this section,
 see the following resources:
 
-- :node-api-3.6:`find() API documentation <GridFSBucket.html#find>`
-- :node-api-3.6:`Cursor API documentation <Cursor.html>`
+- `find() API documentation <{+node-api+}/GridFSBucket.html#find>`__
+- `Cursor API documentation <{+node-api+}/Cursor.html>`__
 - :doc:`Cursor Fundamentals page </fundamentals/crud/read-operations/cursor>`
 - :doc:`Read Operations page </fundamentals/crud/read-operations/>`
 
@@ -200,7 +200,7 @@ method, which takes the ``_id`` field of a file as a parameter:
    overhead.
 
 For more information on the ``openDownloadStreamByName()`` method, see
-its :node-api-3.6:`API documentation <GridFSBucket.html#openDownloadStreamByName>`.
+its `API documentation <{+node-api+}/GridFSBucket.html#openDownloadStreamByName>`__.
 
 .. _gridfs-rename-files:
 
@@ -226,8 +226,8 @@ The following example shows how to update the ``filename`` field to
 
    bucket.rename(ObjectId("60edece5e06275bf0463aaf3"), "newFileName");
 
-For more information on this method, see the :node-api-3.6:`rename() API
-documentation <GridFSBucket.html#rename>`.
+For more information on this method, see the `rename() API
+documentation <{+node-api+}/GridFSBucket.html#rename>`__.
 
 .. _gridfs-delete-files:
 
@@ -250,8 +250,8 @@ The following example shows you how to delete a file by referencing its ``_id`` 
 
    bucket.delete(ObjectId("60edece5e06275bf0463aaf3"));
 
-For more information on this method, see the :node-api-3.6:`delete() API
-documentation <GridFSBucket.html#delete>`.
+For more information on this method, see the `delete() API
+documentation <{+node-api+}/GridFSBucket.html#delete>`__.
 
 .. _gridfs-delete-bucket:
 
@@ -266,8 +266,8 @@ code example shows you how to delete a GridFS bucket:
 
    bucket.drop();
 
-For more information on this method, see the :node-api-3.6:`drop() API
-documentation <GridFSBucket.html#drop>`.
+For more information on this method, see the `drop() API
+documentation <{+node-api+}/GridFSBucket.html#drop>`__.
 
 Additional Resources
 --------------------

--- a/source/fundamentals/logging.txt
+++ b/source/fundamentals/logging.txt
@@ -222,4 +222,4 @@ The output of the example resembles the following:
    }
 
 For more information on the methods available on the ``Logger``, see the
-:node-api-3.6:`Logger API documentation <Logger.html>`.
+`Logger API documentation <{+node-api+}/Logger.html>`__.

--- a/source/fundamentals/promises.txt
+++ b/source/fundamentals/promises.txt
@@ -92,7 +92,7 @@ a ``catch()`` method to the end of a Promise chain.
 
    Certain methods in the driver such as ``find()`` return a ``Cursor``
    instead of a Promise. To determine what type each method returns, refer to
-   the :node-api-3.6:`Node.js API documentation <>`.
+   the `Node.js API documentation <{+node-api+}/>`__.
 
 Await
 ~~~~~
@@ -153,7 +153,7 @@ snippet:
    );
 
 For more information on the callback method signature for the specific
-driver method, see the :node-api-3.6:`API documentation <>`.
+driver method, see the `API documentation <{+node-api+}/>`__.
 
 .. note::
 

--- a/source/fundamentals/versioned-api.txt
+++ b/source/fundamentals/versioned-api.txt
@@ -85,7 +85,7 @@ following operations:
 For more information on the methods and classes referenced in this
 section, see the following API Documentation:
 
-- :node-api-4.0:`ServerApiVersion </modules.html#serverapiversion>`__
+- :node-api-4.0:`ServerApiVersion </modules.html#serverapiversion>`
 - `MongoClientOptions </{+node-api+}global.html#MongoClientOptions>`__
 - `MongoClient <{+node-api+}/MongoClient.html>`__
 

--- a/source/fundamentals/versioned-api.txt
+++ b/source/fundamentals/versioned-api.txt
@@ -86,7 +86,7 @@ For more information on the methods and classes referenced in this
 section, see the following API Documentation:
 
 - :node-api-4.0:`ServerApiVersion </modules.html#serverapiversion>`
-- `MongoClientOptions </{+node-api+}global.html#MongoClientOptions>`__
+- `MongoClientOptions <{+node-api+}/global.html#MongoClientOptions>`__
 - `MongoClient <{+node-api+}/MongoClient.html>`__
 
 .. _versioned-api-options:

--- a/source/fundamentals/versioned-api.txt
+++ b/source/fundamentals/versioned-api.txt
@@ -85,9 +85,9 @@ following operations:
 For more information on the methods and classes referenced in this
 section, see the following API Documentation:
 
-- :node-api-4.0:`ServerApiVersion </modules.html#serverapiversion>`
-- :node-api-4.0:`MongoClientOptions </interfaces/mongoclientoptions.html>`
-- :node-api-4.0:`MongoClient </classes/mongoclient.html>`
+- :node-api-4.0:`ServerApiVersion </modules.html#serverapiversion>`__
+- `MongoClientOptions </{+node-api+}global.html#MongoClientOptions>`__
+- `MongoClient <{+node-api+}/MongoClient.html>`__
 
 .. _versioned-api-options:
 

--- a/source/index.txt
+++ b/source/index.txt
@@ -96,7 +96,7 @@ material on using the Node.js driver for the following:
 
 API
 ---
-See the :node-api-3.6:`API documentation <>` if you are looking for
+See the `API documentation <{+node-api+}>`__ if you are looking for
 technical information about classes, methods, and configuration objects
 within the MongoDB Node.js driver.
 

--- a/source/usage-examples/bulkWrite.txt
+++ b/source/usage-examples/bulkWrite.txt
@@ -9,7 +9,7 @@ Perform Bulk Operations
    do not specify one, this method returns a ``Promise`` that resolves to
    the result object when it completes. See our guide on :doc:`Promises
    and Callbacks </fundamentals/promises>` for more information, or the
-   :node-api-3.6:`API documentation <BulkWriteResult.html>` for information on
+   `API documentation <{+node-api+}/BulkWriteResult.html>`__ for information on
    the result object.
 
 The ``bulkWrite()`` method performs batch write operations against a
@@ -33,7 +33,7 @@ The ``bulkWrite()`` method accepts the following parameters:
 - ``operations``: specifies the bulk write operations to
   perform. Pass each operation to ``bulkWrite()`` as an object in
   an array. For examples that show the syntax for each write operation, see
-  the :node-api-3.6:`bulkWrite API documentation <Collection.html#bulkWrite>`.
+  the `bulkWrite API documentation <{+node-api+}/Collection.html#bulkWrite>`__.
 
 - ``options``: *optional* settings that affect the execution
   of the operation, such as whether the write operations should execute in

--- a/source/usage-examples/changeStream.txt
+++ b/source/usage-examples/changeStream.txt
@@ -25,7 +25,7 @@ In the example below, the ``$match`` stage will match all change event documents
 The ``watch()`` method accepts an ``options`` object as the second parameter. Refer to the links at the end of this
 section for more information on the settings you can configure with this object.
 
-The ``watch()`` method returns an instance of a :node-api-3.6:`ChangeStream <ChangeStream.html>`. You can read events from
+The ``watch()`` method returns an instance of a `ChangeStream <{+node-api+}/ChangeStream.html>`__. You can read events from
 change streams by iterating over them or listening for events. Select the tab that corresponds to the way you want to
 read events from the change stream below.
 
@@ -63,7 +63,7 @@ read events from the change stream below.
 
       You can control the change stream by calling ``pause()`` to stop emitting events or ``resume()`` to continue to emit events.
 
-      To stop processing change events, call the :node-api-3.6:`close() <ChangeStream.html#close>` method on the
+      To stop processing change events, call the `close() <{+node-api+}/ChangeStream.html#close>`__ method on the
       ``ChangeStream`` instance. This closes the change stream and frees resources.
 
       .. code-block:: javascript
@@ -77,10 +77,10 @@ methods presented above:
 - :manual:`Change events </reference/change-events/>`
 - :manual:`Aggregation pipeline </reference/operator/aggregation-pipeline/>`
 - :manual:`Aggregation stages </changeStreams/#modify-change-stream-output>`
-- :node-api-3.6:`ChangeStream class API documentation <ChangeStream.html>`
-- :node-api-3.6:`Collection.watch() <Collection.html#watch>`,
-- :node-api-3.6:`Db.watch() <Db.html#watch>`,
-- :node-api-3.6:`MongoClient.watch() API documentation <MongoClient.html#watch>`
+- `ChangeStream class API documentation <{+node-api+}/ChangeStream.html>`__
+- `Collection.watch() <{+node-api+}/Collection.html#watch>`__
+- `Db.watch() <{+node-api+}/Db.html#watch>`__
+- `MongoClient.watch() API documentation <{+node-api+}/MongoClient.html#watch>`__
 
 Example
 -------

--- a/source/usage-examples/command.txt
+++ b/source/usage-examples/command.txt
@@ -9,11 +9,11 @@ Run a Command
    not specify one, this method returns a ``Promise`` that resolves to the
    result object when it completes. See our guide on :doc:`Promises and
    Callbacks </fundamentals/promises>` for more information, or the
-   :node-api-3.6:`API documentation <Db.html#~resultCallback>` for
+   `API documentation <{+node-api+}/Db.html#~resultCallback>`__ for
    information on the result object.
 
-You can run all raw database operations using the :node-api-3.6:`db.command()
-<Db.html#~command>` method. Call the ``command()`` method with
+You can run all raw database operations using the `db.command()
+<{+node-api+}/Db.html#~command>`__ method. Call the ``command()`` method with
 your command object on an instance of a database for diagnostic and
 administrative tasks such as fetching server stats or initializing a replica
 set.
@@ -25,8 +25,8 @@ set.
 You can specify additional options in the ``options`` object passed in
 the second parameter of the ``command()`` method. For more information
 on the options you can pass, see the
-:node-api-3.6:`db.command() API documentation <Db.html#~command>`. You can
-also pass a :node-api-3.6:`callback method <Admin.html#~resultCallback>` as an
+`db.command() API documentation <{+node-api+}/Db.html#~command>`__. You can
+also pass a `callback method <{+node-api+}/Admin.html#~resultCallback>`__ as an
 optional third parameter.
 
 Example

--- a/source/usage-examples/count.txt
+++ b/source/usage-examples/count.txt
@@ -10,20 +10,20 @@ Count Documents
    this method returns a ``Promise`` that resolves to the result object
    when it completes. See our guide on :doc:`Promises and Callbacks
    </fundamentals/promises>` for more information, or the
-   :node-api-3.6:`API documentation <Collection.html#~countCallback>` for
+   `API documentation <{+node-api+}/Collection.html#~countCallback>`__ for
    information on the result object.
 
 The Node.js driver provides two methods for counting documents in a
 collection:
 
-- :node-api-3.6:`collection.countDocuments()
-  <Collection.html#countDocuments>` returns the number of documents in
+- `collection.countDocuments()
+  <{+node-api+}/Collection.html#countDocuments>`__ returns the number of documents in
   the collection that match the specified query. If you specify an empty
   query document, ``countDocuments()`` returns the total number of
   documents in the collection.
 
-- :node-api-3.6:`collection.estimatedDocumentCount()
-  <Collection.html#estimatedDocumentCount>` returns an
+- `collection.estimatedDocumentCount()
+  <{+node-api+}/Collection.html#estimatedDocumentCount>`__ returns an
   **estimation** of the number of documents in the collection based on
   collection metadata.
 

--- a/source/usage-examples/deleteMany.txt
+++ b/source/usage-examples/deleteMany.txt
@@ -9,24 +9,24 @@ Delete Multiple Documents
    do not specify one, this method returns a ``Promise`` that resolves to the
    result object when it completes. See our guide on :doc:`Promises and
    Callbacks </fundamentals/promises>` for more information, or the
-   :node-api-3.6:`API documentation <Collection.html#~deleteWriteOpResult>` for
+   `API documentation <{+node-api+}/Collection.html#~deleteWriteOpResult>`__ for
    information on the result object.
 
 You can delete several documents in a collection at once using the
-:node-api-3.6:`collection.deleteMany() <Collection.html#deleteMany>` method.
+`collection.deleteMany() <{+node-api+}/Collection.html#deleteMany>`__ method.
 Pass a query document to the ``deleteMany()`` method to specify a subset
 of documents in the collection to delete. If you do not provide a query
 document (or if you provide an empty document), MongoDB matches all documents
 in the collection and deletes them. While you can use ``deleteMany()``
 to delete all documents in a collection, consider using
-:node-api-3.6:`drop() <Collection.html#drop>` instead for better performance
+`drop() <{+node-api+}/Collection.html#drop>`__ instead for better performance
 and clearer code.
 
 You can specify additional options in the ``options`` object passed in
 the second parameter of the ``deleteMany()`` method. You can also pass a
 callback method as the optional third parameter. For more detailed 
 information, see the 
-:node-api-3.6:`deleteMany() API documentation <Collection.html#deleteMany>`.
+`deleteMany() API documentation <{+node-api+}/Collection.html#deleteMany>`__.
 
 Example
 -------

--- a/source/usage-examples/deleteOne.txt
+++ b/source/usage-examples/deleteOne.txt
@@ -9,7 +9,7 @@ Delete a Document
    do not specify one, this method returns a ``Promise`` that resolves to the
    result object when it completes. See our guide on :doc:`Promises and
    Callbacks </fundamentals/promises>` for more information, or the
-   :node-api-3.6:`API documentation <Collection.html#~deleteWriteOpResult>` for
+   `API documentation <{+node-api+}/Collection.html#~deleteWriteOpResult>`__ for
    information on the result object.
 
 You can delete a single document in a collection with
@@ -23,17 +23,17 @@ deletes the first match.
 You can specify additional query options using the
 ``options`` object passed as the second parameter of the
 ``deleteOne`` method. You can also pass a
-:node-api-3.6:`callback method <Collection.html#~deleteWriteOpCallback>`
+`callback method <{+node-api+}/Collection.html#~deleteWriteOpCallback>`__
 as an optional third parameter. For more information on this method,
 see the
-:node-api-3.6:`deleteOne() API documentation <Collection.html#deleteOne>`.
+`deleteOne() API documentation <{+node-api+}/Collection.html#deleteOne>`__.
 
 .. note::
 
   If your application requires the deleted document after deletion,
   consider using the
-  :node-api-3.6:`collection.findOneAndDelete()
-  <Collection.html#findOneAndDelete>`.
+  `collection.findOneAndDelete()
+  <{+node-api+}/Collection.html#findOneAndDelete>`__.
   method, which has a similar interface to ``deleteOne()`` but also
   returns the deleted document.
 

--- a/source/usage-examples/distinct.txt
+++ b/source/usage-examples/distinct.txt
@@ -9,12 +9,12 @@ Retrieve Distinct Values of a Field
    not specify one, this method returns a ``Promise`` that resolves to the
    result object when it completes. See our guide on :doc:`Promises and
    Callbacks </fundamentals/promises>` for more information, or the
-   :node-api-3.6:`API documentation <Collection.html#~resultCallback>` for
+   `API documentation <{+node-api+}/Collection.html#~resultCallback>`__ for
    information on the result object.
 
 You can retrieve a list of distinct values for a field across a
-collection by using the :node-api-3.6:`collection.distinct()
-<Collection.html#distinct>` method. Call the ``distinct()`` method
+collection by using the `collection.distinct()
+<{+node-api+}/Collection.html#distinct>`__ method. Call the ``distinct()`` method
 on a ``Collection`` object with a document field name parameter as a
 ``String`` to produce a list that contains one of each of the different
 values found in the specified document field as shown below:
@@ -35,8 +35,8 @@ a method call to the ``wins`` field in the ``awards`` subdocument:
 
 You can specify additional query options using the ``options`` object passed
 as the third parameter to the ``distinct()`` method. For details on the
-query parameters, see the :node-api-3.6:`distinct() method in the API
-documentation <Collection.html#distinct>`.
+query parameters, see the `distinct() method in the API
+documentation <{+node-api+}/Collection.html#distinct>`__.
 
 If you specify a value for the document field name that is not of type
 ``String`` such as a ``Document``, ``Array``, ``Number``, or ``null``,

--- a/source/usage-examples/find.txt
+++ b/source/usage-examples/find.txt
@@ -18,10 +18,10 @@ and
 :doc:`projection </fundamentals/crud/read-operations/project>`
 to configure the result set. You can specify these in the options
 parameter in your ``find()`` method call in ``sort`` and ``projection``
-objects. See :node-api-3.6:`collection.find() <Collection.html#find>` for more
+objects. See `collection.find() <{+node-api+}/Collection.html#find>`__ for more
 information on the parameters you can pass to the method.
 
-The ``find()`` method returns a :node-api-3.6:`Cursor <Cursor.html>` that
+The ``find()`` method returns a `Cursor <{+node-api+}/Cursor.html>`__ that
 manages the results of your query. You can iterate through the matching
 documents using one of the following :ref:`cursor methods <cursor-methods>`:
 

--- a/source/usage-examples/findOne.txt
+++ b/source/usage-examples/findOne.txt
@@ -9,7 +9,7 @@ Find a Document
    not specify one, this method returns a ``Promise`` that resolves to the
    result object when it completes. See our guide on :doc:`Promises and
    Callbacks </fundamentals/promises>` for more information, or the
-   :node-api-3.6:`API documentation <Collection.html#~resultCallback>` for
+   `API documentation <{+node-api+}/Collection.html#~resultCallback>`__ for
    information on the result object.
 
 You can query for a single document in a collection with the
@@ -27,7 +27,7 @@ and :doc:`projection </fundamentals/crud/read-operations/project>`
 to configure the returned document. You can specify the additional options
 in the ``options`` object passed as the second parameter of the
 ``findOne`` method. For detailed reference documentation, see
-:node-api-3.6:`collection.findOne() <Collection.html#findOne>`.
+`collection.findOne() <{+node-api+}/Collection.html#findOne>`__.
 
 Example
 -------

--- a/source/usage-examples/insertMany.txt
+++ b/source/usage-examples/insertMany.txt
@@ -9,11 +9,11 @@ Insert Multiple Documents
    do not specify one, this method returns a ``Promise`` that resolves to the
    result object when it completes. See our guide on :doc:`Promises and
    Callbacks </fundamentals/promises>` for more information, or the
-   :node-api-3.6:`API documentation <Collection.html#~insertWriteOpResult>` for
+   `API documentation <{+node-api+}/Collection.html#~insertWriteOpResult>`__ for
    information on the result object.
 
-You can insert multiple documents using the :node-api-3.6:`collection.insertMany()
-<Collection.html#insertMany>` method. The ``insertMany()`` takes an array
+You can insert multiple documents using the `collection.insertMany()
+<{+node-api+}/Collection.html#insertMany>`__ method. The ``insertMany()`` takes an array
 of documents to insert into the specified collection.
 
 You can specify additional options in the ``options`` object passed as the

--- a/source/usage-examples/insertOne.txt
+++ b/source/usage-examples/insertOne.txt
@@ -9,21 +9,21 @@ Insert a Document
    do not specify one, this method returns a ``Promise`` that resolves to the 
    result object when it completes. See our guide on :doc:`Promises and
    Callbacks </fundamentals/promises>` for more information, or the
-   :node-api-3.6:`API documentation <Collection.html#~insertOneWriteOpResult>` for
+   `API documentation <{+node-api+}/Collection.html#~insertOneWriteOpResult>`__ for
    information on the result object.
 
 You can insert a document into a collection using the
-:node-api-3.6:`collection.insertOne() <Collection.html#insertOne>` method. To
+`collection.insertOne() <{+node-api+}/Collection.html#insertOne>`__ method. To
 insert a document, define an object that contains the fields and values that
 you want to store. If the specified collection does not exist, the
 ``insertOne()`` method creates the collection.
 
 You can specify additional query options using the ``options`` parameter.
 For more information on the method parameters, see the
-:node-api-3.6:`insertOne() API documentation <Collection.html#insertOne>`. You
+`insertOne() API documentation <{+node-api+}/Collection.html#insertOne>`__. You
 can also pass a callback method as an optional third parameter.
 For more information on this method, see the
-:node-api-3.6:`insertOne() API documentation <Collection.html#insertOne>`.
+`insertOne() API documentation <{+node-api+}/Collection.html#insertOne>`__.
 
 The ``insertedId`` field of this object is the ``_id`` of the
 inserted document. If the operation fails to create a document, the

--- a/source/usage-examples/replaceOne.txt
+++ b/source/usage-examples/replaceOne.txt
@@ -9,11 +9,11 @@ Replace a Document
    do not specify one, this method returns a ``Promise`` that resolves to the
    result object when it completes. See our guide on :doc:`Promises and
    Callbacks </fundamentals/promises>` for more information, or the
-   :node-api-3.6:`API documentation <Collection.html#~updateWriteOpResult>` for
+   `API documentation <{+node-api+}/Collection.html#~updateWriteOpResult>`__ for
    information on the result object.
 
 You can replace a single document using the
-:node-api-3.6:`collection.replaceOne() <Collection.html#replaceOne>` method.
+`collection.replaceOne() <{+node-api+}/Collection.html#replaceOne>`__ method.
 ``replaceOne()`` accepts a query document and a replacement document. If
 the query matches a document in the collection, it replaces the first
 document that matches the query with the provided replacement document.
@@ -33,8 +33,8 @@ unique index rule, ``replaceOne()`` throws a ``duplicate key error``.
 .. note::
 
   If your application requires the document after updating,
-  use the :node-api-3.6:`collection.findOneAndReplace()
-  <Collection.html#findOneAndReplace>`
+  use the `collection.findOneAndReplace()
+  <{+node-api+}/Collection.html#findOneAndReplace>`__
   method which has a similar interface to ``replaceOne()``.
   You can configure ``findOneAndReplace()`` to return either the
   original matched document or the replacement document.

--- a/source/usage-examples/updateMany.txt
+++ b/source/usage-examples/updateMany.txt
@@ -9,11 +9,11 @@ Update Multiple Documents
    do not specify one, this method returns a ``Promise`` that resolves to the
    result object when it completes. See our guide on :doc:`Promises and
    Callbacks </fundamentals/promises>` for more information, or see the
-   :node-api-3.6:`API documentation <Collection.html#~resultCallback>` for
+   `API documentation <{+node-api+}/Collection.html#~resultCallback>`__ for
    information on the result object.
 
 You can update multiple documents using the
-:node-api-3.6:`collection.updateMany() <Collection.html#updateMany>` method.
+`collection.updateMany() <{+node-api+}/Collection.html#updateMany>`__ method.
 The ``updateMany()`` method accepts a filter document and an update document. If the query matches documents in the
 collection, the method applies the updates from the update document to fields
 and values of the matching documents. The update document requires an :manual:`update operator
@@ -21,8 +21,8 @@ and values of the matching documents. The update document requires an :manual:`u
 
 You can specify additional options in the ``options`` object passed in
 the third parameter of the ``updateMany()`` method. For more detailed
-information, see :node-api-3.6:`the updateMany() API documentation
-<Collection.html#updateMany>`.
+information, see `the updateMany() API documentation
+<{+node-api+}/Collection.html#updateMany>`__.
 
 Example
 -------

--- a/source/usage-examples/updateOne.txt
+++ b/source/usage-examples/updateOne.txt
@@ -9,11 +9,11 @@ Update a Document
    do not specify one, this method returns a ``Promise`` that resolves to the
    result object when it completes. See our guide on :doc:`Promises and
    Callbacks </fundamentals/promises>` for more information, or see the
-   :node-api-3.6:`API documentation <Collection.html#~updateWriteOpResult>` for
+   `API documentation <{+node-api+}/Collection.html#~updateWriteOpResult>`__ for
    information on the result object.
 
 You can update a single document using the 
-:node-api-3.6:`collection.updateOne() <Collection.html#updateOne>`
+`collection.updateOne() <{+node-api+}/Collection.html#updateOne>`__
 method. The ``updateOne()`` method accepts a filter
 document and an update document. If the query matches documents in the
 collection, the method applies the updates from the update document to fields
@@ -25,7 +25,7 @@ You can specify additional query options using the ``options`` object
 passed as the second parameter of the ``updateOne()`` method.
 Set the ``upsert`` option to ``true`` to create a new document
 if no documents match the filter. For additional information, see the
-:node-api-3.6:`updateOne() API documentation <Collection.html#updateOne>`.
+`updateOne() API documentation <{+node-api+}/Collection.html#updateOne>`__.
 
 ``updateOne()`` throws an exception if an error occurs during execution.
 If you specify a value in your update document for the immutable field
@@ -36,8 +36,8 @@ key error`` exception.
 .. note::
 
   If your application requires the document after updating,
-  consider using the :node-api-3.6:`collection.findOneAndUpdate()
-  <Collection.html#findOneAndUpdate>`. method, which has a similar
+  consider using the `collection.findOneAndUpdate()
+  <{+node-api+}/Collection.html#findOneAndUpdate>`__. method, which has a similar
   interface to ``updateOne()`` but also returns the original or updated
   document.
 


### PR DESCRIPTION
## Pull Request Info

Replaced API directive with a constant.
Note: There is no 3.7 link for `serverapiversion` and `serverapi` on the Versioned API page. I confirmed with an engineer that it's ok to link to 4.0 since it's the same logic.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-18482

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=613005017dcf012930cee60f

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-18482-APIConstants/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
