### PR TITLE
Docsp 18513

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -4,7 +4,5 @@ title = "Node.js"
 toc_landing_pages = ["/fundamentals/authentication", "/fundamentals", "/fundamentals/crud", "/usage-examples"]
 
 [constants]
-version = 4.0
-package-name-org = "mongodb-org"
-pgp-version = "{+version+}"
-node-api = "https://mongodb.github.io/node-mongodb-native/{+version+}"
+version = 4.1
+api = "https://mongodb.github.io/node-mongodb-native/{+version+}"

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -29,7 +29,7 @@ What Is the Difference Between "connectTimeoutMS", "socketTimeoutMS" and "maxTim
 
        .. tip::
 
-          To modify the allowed time for :node-api-4.0:`MongoClient.connect </classes/mongoclient.html#.connect>` to establish a
+          To modify the allowed time for `MongoClient.connect <{+api+}/classes/mongoclient.html#.connect>`__ to establish a
           connection to a MongoDB server, use the ``serverSelectionTimeoutMS`` option instead.
 
        **Default:** 10000
@@ -39,14 +39,14 @@ What Is the Difference Between "connectTimeoutMS", "socketTimeoutMS" and "maxTim
        never time out the socket. This option applies only to sockets that
        have already been connected.
    * - maxTimeMS
-     - :node-api-4.0:`maxTimeMS </classes/findcursor.html#maxtimems>` is the maximum
+     - `maxTimeMS <{+api+}/classes/findcursor.html#maxtimems>`__ is the maximum
        amount of time the server should wait for an operation to complete
        after it has reached the server. If an operation runs over the
        specified time limit, it returns a timeout error.
 
 To specify the optional settings for your ``MongoClient``, declare one or
 more available settings in the ``options`` object of the constructor as
-follows: 
+follows:
 
 .. code-block:: javascript
 
@@ -56,8 +56,8 @@ follows:
    });
 
 To see all the available settings, see the
-:node-api-4.0:`MongoClientOptions </interfaces/mongoclientoptions.html>`
-API Documentation. 
+`MongoClientOptions <{+api+}/interfaces/mongoclientoptions.html>`__
+API Documentation.
 
 How Can I Prevent the Driver From Hanging During Connection or From Spending Too Long Trying to Reach Unreachable Replica Sets?
 -------------------------------------------------------------------------------------------------------------------------------

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -29,7 +29,7 @@ What Is the Difference Between "connectTimeoutMS", "socketTimeoutMS" and "maxTim
 
        .. tip::
 
-          To modify the allowed time for `MongoClient.connect <{+api+}/classes/mongoclient.html#.connect>`__ to establish a
+          To modify the allowed time for `MongoClient.connect <{+api+}/classes/MongoClient.html#connect>`__ to establish a
           connection to a MongoDB server, use the ``serverSelectionTimeoutMS`` option instead.
 
        **Default:** 10000
@@ -39,7 +39,7 @@ What Is the Difference Between "connectTimeoutMS", "socketTimeoutMS" and "maxTim
        never time out the socket. This option applies only to sockets that
        have already been connected.
    * - maxTimeMS
-     - `maxTimeMS <{+api+}/classes/findcursor.html#maxtimems>`__ is the maximum
+     - `maxTimeMS <{+api+}/classes/FindCursor.html#maxTimeMS>`__ is the maximum
        amount of time the server should wait for an operation to complete
        after it has reached the server. If an operation runs over the
        specified time limit, it returns a timeout error.
@@ -56,7 +56,7 @@ follows:
    });
 
 To see all the available settings, see the
-`MongoClientOptions <{+api+}/interfaces/mongoclientoptions.html>`__
+`MongoClientOptions <{+api+}/interfaces/MongoClientOptions.html>`__
 API Documentation.
 
 How Can I Prevent the Driver From Hanging During Connection or From Spending Too Long Trying to Reach Unreachable Replica Sets?

--- a/source/fundamentals/aggregation.txt
+++ b/source/fundamentals/aggregation.txt
@@ -54,7 +54,7 @@ Aggregation operations have some :manual:`limitations </core/aggregation-pipelin
 
 - Pipeline stages have a memory limit of 100 megabytes by default. If necessary, you may exceed this limit by setting the ``allowDiskUse``
   property of ``AggregateOptions`` to ``true``. See the
-  :node-api-4.0:`AggregateOptions API documentation <interfaces/aggregateoptions.html>`
+  `AggregateOptions API documentation <{+api+}interfaces/aggregateoptions.html>`__
   for more details.
 
 .. important:: ``$graphLookup`` exception
@@ -91,7 +91,7 @@ database:
 Aggregation Example
 ~~~~~~~~~~~~~~~~~~~
 
-To perform an aggregation, pass a list of aggregation stages to the 
+To perform an aggregation, pass a list of aggregation stages to the
 ``collection.aggregate()`` method.
 
 In the example, the aggregation pipeline uses the following aggregation stages:
@@ -116,10 +116,10 @@ This example should produce the following output:
    { _id: 4, count: 2 }
    { _id: 3, count: 1 }
    { _id: 5, count: 1 }
-   
-For more information, see the :node-api-4.0:`aggregate() API documentation <classes/collection.html#aggregate>`.
+
+For more information, see the `aggregate() API documentation <{+api+}classes/collection.html#aggregate>`__.
 
 Additional Aggregation Examples
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 You can find another aggregation framework example `in this MongoDB Blog
-post <https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-analyze-data-using-the-aggregation-framework>`_. 
+post <https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-analyze-data-using-the-aggregation-framework>`_.

--- a/source/fundamentals/aggregation.txt
+++ b/source/fundamentals/aggregation.txt
@@ -54,7 +54,7 @@ Aggregation operations have some :manual:`limitations </core/aggregation-pipelin
 
 - Pipeline stages have a memory limit of 100 megabytes by default. If necessary, you may exceed this limit by setting the ``allowDiskUse``
   property of ``AggregateOptions`` to ``true``. See the
-  `AggregateOptions API documentation <{+api+}interfaces/aggregateoptions.html>`__
+  `AggregateOptions API documentation <{+api+}/interfaces/AggregateOptions.html>`__
   for more details.
 
 .. important:: ``$graphLookup`` exception
@@ -117,7 +117,7 @@ This example should produce the following output:
    { _id: 3, count: 1 }
    { _id: 5, count: 1 }
 
-For more information, see the `aggregate() API documentation <{+api+}classes/collection.html#aggregate>`__.
+For more information, see the `aggregate() API documentation <{+api+}/classes/Collection.html#aggregate>`__.
 
 Additional Aggregation Examples
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/fundamentals/collations.txt
+++ b/source/fundamentals/collations.txt
@@ -284,7 +284,7 @@ contains the following documents:
 Aggregation Example
 ```````````````````
 
-To use collation with the `aggregate <{+api+}/classes/collection.html#aggregate>`__
+To use collation with the `aggregate <{+api+}/classes/Collection.html#aggregate>`__
 operation, pass the collation document in the options field, after the
 array of pipeline stages.
 

--- a/source/fundamentals/collations.txt
+++ b/source/fundamentals/collations.txt
@@ -284,7 +284,7 @@ contains the following documents:
 Aggregation Example
 ```````````````````
 
-To use collation with the :node-api-4.0:`aggregate </classes/collection.html#aggregate>`
+To use collation with the `aggregate <{+api+}/classes/collection.html#aggregate>`__
 operation, pass the collation document in the options field, after the
 array of pipeline stages.
 

--- a/source/fundamentals/connection.txt
+++ b/source/fundamentals/connection.txt
@@ -339,4 +339,4 @@ URI to specify the behavior of the client.
 
 
 
-For a complete list of options, see the :node-api-4.0:`MongoClient </classes/mongoclient.html>` API reference page.
+For a complete list of options, see the `MongoClient <{+api+}/classes/mongoclient.html>`__ API reference page.

--- a/source/fundamentals/connection.txt
+++ b/source/fundamentals/connection.txt
@@ -339,4 +339,4 @@ URI to specify the behavior of the client.
 
 
 
-For a complete list of options, see the `MongoClient <{+api+}/classes/mongoclient.html>`__ API reference page.
+For a complete list of options, see the `MongoClient <{+api+}/classes/MongoClient.html>`__ API reference page.

--- a/source/fundamentals/crud/compound-operations.txt
+++ b/source/fundamentals/crud/compound-operations.txt
@@ -42,15 +42,15 @@ Built-in Methods
 
 There are three major compound operations:
 
-- :node-api-4.0:`findOneAndDelete() </classes/collection.html#findoneanddelete>`
+- `findOneAndDelete() <{+api+}/classes/collection.html#findoneanddelete>`__
   matches multiple documents to a supplied query and removes the first
   of those matched documents.
 
-- :node-api-4.0:`findOneAndUpdate() </classes/collection.html#findoneandupdate>`
+- `findOneAndUpdate() <{+api+}/classes/collection.html#findoneandupdate>`__
   matches multiple documents to a supplied query and updates the first
   of those matched documents using the provided update document.
 
-- :node-api-4.0:`findOneAndReplace() </classes/collection.html#findoneandreplace>`
+- `findOneAndReplace() <{+api+}/classes/collection.html#findoneandreplace>`__
   matches multiple documents to a supplied query and replaces the first
   of those matched documents using the provided replacement document.
 

--- a/source/fundamentals/crud/compound-operations.txt
+++ b/source/fundamentals/crud/compound-operations.txt
@@ -42,15 +42,15 @@ Built-in Methods
 
 There are three major compound operations:
 
-- `findOneAndDelete() <{+api+}/classes/collection.html#findoneanddelete>`__
+- `findOneAndDelete() <{+api+}/classes/Collection.html#findOneAndDelete>`__
   matches multiple documents to a supplied query and removes the first
   of those matched documents.
 
-- `findOneAndUpdate() <{+api+}/classes/collection.html#findoneandupdate>`__
+- `findOneAndUpdate() <{+api+}/classes/Collection.html#findOneAndUpdate>`__
   matches multiple documents to a supplied query and updates the first
   of those matched documents using the provided update document.
 
-- `findOneAndReplace() <{+api+}/classes/collection.html#findoneandreplace>`__
+- `findOneAndReplace() <{+api+}/classes/Collection.html#findOneAndReplace>`__
   matches multiple documents to a supplied query and replaces the first
   of those matched documents using the provided replacement document.
 

--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -71,7 +71,7 @@ pulling all matching documents into a collection in process memory.
 For Each Functional Iteration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can pass a function to the :node-api-4.0:`forEach() </classes/findcursor.html#foreach>` method of any cursor to iterate through
+You can pass a function to the `forEach() <{+api+}/classes/findcursor.html#foreach>`__ method of any cursor to iterate through
 results in a functional style:
 
 .. literalinclude:: /code-snippets/crud/cursor.js
@@ -83,11 +83,11 @@ Return an Array of All Documents
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For use cases that require all documents matched by a query to be held
-in memory at the same time, use :node-api-4.0:`toArray() </classes/findcursor.html#toarray>`. 
+in memory at the same time, use `toArray() <{+api+}/classes/findcursor.html#toarray>`__.
 Note that large numbers of matched documents can cause performance issues
 or failures if the operation exceeds memory constraints. Consider using
-:node-api-4.0:`forEach() </classes/findcursor.html#foreach>` to iterate
-through results unless you want to return all documents at once. 
+`forEach() <{+api+}/classes/findcursor.html#foreach>`__ to iterate
+through results unless you want to return all documents at once.
 
 .. literalinclude:: /code-snippets/crud/cursor.js
    :language: javascript
@@ -109,9 +109,9 @@ allows you to use cursors in ``for``...``await`` loops:
 Manual Iteration
 ~~~~~~~~~~~~~~~~
 
-You can use the :node-api-4.0:`hasNext() </classes/findcursor.html#hasnext>`
+You can use the `hasNext() <{+api+}/classes/findcursor.html#hasnext>`__
 method to check if a cursor can provide additional data, and then use
-the :node-api-4.0:`next() </classes/findcursor.html#next>`
+the `next() <{+api+}/classes/findcursor.html#next>`__
 method to retrieve the subsequent element of the cursor:
 
 .. literalinclude:: /code-snippets/crud/cursor.js
@@ -148,7 +148,7 @@ Count
 ~~~~~
 
 For an estimated count of the number of documents referenced by the
-cursor, use :node-api-4.0:`count() </classes/findcursor.html#count>`:
+cursor, use `count() <{+api+}/classes/findcursor.html#count>`__:
 
 .. literalinclude:: /code-snippets/crud/cursor.js
    :language: javascript
@@ -159,7 +159,7 @@ Rewind
 ~~~~~~
 
 To reset a cursor to its initial position in the set of returned
-documents, use :node-api-4.0:`rewind() </classes/findcursor.html#rewind>`.
+documents, use `rewind() <{+api+}/classes/findcursor.html#rewind>`__.
 
 .. literalinclude:: /code-snippets/crud/cursor.js
    :language: javascript
@@ -171,7 +171,7 @@ Close
 
 Cursors consume memory and network resources both in the client
 application and in the connected instance of MongoDB. Use
-:node-api-4.0:`close() </classes/findcursor.html#close>`
+`close() <{+api+}/classes/findcursor.html#close>`__
 to free up a cursor's resources in both the client application
 and the MongoDB server:
 

--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -71,7 +71,7 @@ pulling all matching documents into a collection in process memory.
 For Each Functional Iteration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can pass a function to the `forEach() <{+api+}/classes/findcursor.html#foreach>`__ method of any cursor to iterate through
+You can pass a function to the `forEach() <{+api+}/classes/FindCursor.html#forEach>`__ method of any cursor to iterate through
 results in a functional style:
 
 .. literalinclude:: /code-snippets/crud/cursor.js
@@ -83,10 +83,10 @@ Return an Array of All Documents
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For use cases that require all documents matched by a query to be held
-in memory at the same time, use `toArray() <{+api+}/classes/findcursor.html#toarray>`__.
+in memory at the same time, use `toArray() <{+api+}/classes/FindCursor.html#toArray>`__.
 Note that large numbers of matched documents can cause performance issues
 or failures if the operation exceeds memory constraints. Consider using
-`forEach() <{+api+}/classes/findcursor.html#foreach>`__ to iterate
+`forEach() <{+api+}/classes/FindCursor.html#forEach>`__ to iterate
 through results unless you want to return all documents at once.
 
 .. literalinclude:: /code-snippets/crud/cursor.js
@@ -109,9 +109,9 @@ allows you to use cursors in ``for``...``await`` loops:
 Manual Iteration
 ~~~~~~~~~~~~~~~~
 
-You can use the `hasNext() <{+api+}/classes/findcursor.html#hasnext>`__
+You can use the `hasNext() <{+api+}/classes/FindCursor.html#hasNext>`__
 method to check if a cursor can provide additional data, and then use
-the `next() <{+api+}/classes/findcursor.html#next>`__
+the `next() <{+api+}/classes/FindCursor.html#next>`__
 method to retrieve the subsequent element of the cursor:
 
 .. literalinclude:: /code-snippets/crud/cursor.js
@@ -148,7 +148,7 @@ Count
 ~~~~~
 
 For an estimated count of the number of documents referenced by the
-cursor, use `count() <{+api+}/classes/findcursor.html#count>`__:
+cursor, use `count() <{+api+}/classes/FindCursor.html#count>`__:
 
 .. literalinclude:: /code-snippets/crud/cursor.js
    :language: javascript
@@ -159,7 +159,7 @@ Rewind
 ~~~~~~
 
 To reset a cursor to its initial position in the set of returned
-documents, use `rewind() <{+api+}/classes/findcursor.html#rewind>`__.
+documents, use `rewind() <{+api+}/classes/FindCursor.html#rewind>`__.
 
 .. literalinclude:: /code-snippets/crud/cursor.js
    :language: javascript
@@ -171,7 +171,7 @@ Close
 
 Cursors consume memory and network resources both in the client
 application and in the connected instance of MongoDB. Use
-`close() <{+api+}/classes/findcursor.html#close>`__
+`close() <{+api+}/classes/FindCursor.html#close>`__
 to free up a cursor's resources in both the client application
 and the MongoDB server:
 

--- a/source/fundamentals/crud/read-operations/limit.txt
+++ b/source/fundamentals/crud/read-operations/limit.txt
@@ -94,7 +94,7 @@ calls are equivalent:
 
 For more information on the ``options`` settings for the ``find()``
 method, see the
-`API documentation on find() <{+api+}/classes/collection.html#find>`__.
+`API documentation on find() <{+api+}/classes/Collection.html#find>`__.
 
 Skip
 ----

--- a/source/fundamentals/crud/read-operations/limit.txt
+++ b/source/fundamentals/crud/read-operations/limit.txt
@@ -94,7 +94,7 @@ calls are equivalent:
 
 For more information on the ``options`` settings for the ``find()``
 method, see the
-:node-api-4.0:`API documentation on find() </classes/collection.html#find>`.
+`API documentation on find() <{+api+}/classes/collection.html#find>`__.
 
 Skip
 ----

--- a/source/fundamentals/crud/write-operations/insert.txt
+++ b/source/fundamentals/crud/write-operations/insert.txt
@@ -84,8 +84,8 @@ Your output should look something like this:
 For additional information on the classes and methods mentioned in this
 section, see the following resources:
 
-- API Documentation on `insertOne() <{+api+}/classes/collection.html#insertone>`__
-- API Documentation on `InsertOneResult <{+api+}/interfaces/insertoneresult.html>`__
+- API Documentation on `insertOne() <{+api+}/classes/Collection.html#insertOne>`__
+- API Documentation on `InsertOneResult <{+api+}/interfaces/InsertOneResult.html>`__
 - Server Manual Entry on :manual:`insertOne() </reference/method/db.collection.insertOne/>`
 - Runnable :doc:`Insert a Document Example </usage-examples/insertOne>`
 
@@ -202,7 +202,7 @@ Your output should look something like this:
 For additional information on the classes and methods mentioned in this
 section, see the following resources:
 
-- API Documentation on `insertMany() <{+api+}/classes/collection.html#insertmany>`__
-- API Documentation on `InsertManyResult <{+api+}/interfaces/insertmanyresult.html>`__
+- API Documentation on `insertMany() <{+api+}/classes/Collection.html#insertMany>`__
+- API Documentation on `InsertManyResult <{+api+}/interfaces/InsertManyResult.html>`__
 - Server Manual Entry on :manual:`insertMany() </reference/method/db.collection.insertMany/>`
 - Runnable :doc:`Insert Multiple Documents Example </usage-examples/insertMany>`

--- a/source/fundamentals/crud/write-operations/insert.txt
+++ b/source/fundamentals/crud/write-operations/insert.txt
@@ -9,7 +9,7 @@ Insert a Document
    :backlinks: none
    :depth: 1
    :class: singlecol
-   
+
 Overview
 --------
 
@@ -18,21 +18,21 @@ In this guide, you can learn how to insert documents into MongoDB.
 You can use MongoDB to retrieve, update and delete information. To
 perform any of those operations, that information, such as user profiles
 and orders, needs to exist in MongoDB. For that information to exist,
-you need to first perform an **insert operation**. 
+you need to first perform an **insert operation**.
 
 An insert operation inserts a single or multiple documents in MongoDB
 using the ``insertOne()``, ``insertMany()`` and ``bulkWrite()`` methods.
 
 The following sections focus on ``insertOne()`` and ``insertMany()``. For an
 example on how to use the ``bulkWrite()`` method, see our runnable :doc:`Bulk
-Operations Example </usage-examples/bulkWrite>`. 
+Operations Example </usage-examples/bulkWrite>`.
 
 A Note About ``_id``
 --------------------
 
 When inserting a document, MongoDB enforces one constraint on your
 documents by default. Each document *must* contain a unique ``_id``
-field. 
+field.
 
 There are two ways to manage this field:
 
@@ -40,13 +40,13 @@ There are two ways to manage this field:
 - You can let the driver automatically generate unique ObjectId values.
 
 Unless you have provided strong guarantees for uniqueness, we recommend
-you let the driver automatically generate ``_id`` values. 
+you let the driver automatically generate ``_id`` values.
 
 .. note::
 
    Duplicate ``_id`` values violate unique index constraints, resulting
-   in a ``WriteError``. 
- 
+   in a ``WriteError``.
+
 For additional information about ``_id``, see the Server Manual Entry on
 :manual:`Unique Indexes </core/index-unique/>`.
 
@@ -54,17 +54,17 @@ Insert a Single Document
 ------------------------
 
 Use the ``insertOne()`` method when you want to insert a single
-document. 
+document.
 
 On successful insertion, the method returns an
 ``InsertOneResult`` instance representing the ``_id`` of
-the new document. 
+the new document.
 
 Example
 ~~~~~~~
 
 The following example creates and inserts a document using the
-``insertOne()`` method: 
+``insertOne()`` method:
 
 .. code-block:: javascript
 
@@ -76,16 +76,16 @@ The following example creates and inserts a document using the
 
 Your output should look something like this:
 
-.. code-block:: 
+.. code-block::
    :copyable: false
 
    A document was inserted with the _id: 60c79c0f4cc72b6bb31e3836
 
 For additional information on the classes and methods mentioned in this
-section, see the following resources: 
+section, see the following resources:
 
-- API Documentation on :node-api-4.0:`insertOne() </classes/collection.html#insertone>` 
-- API Documentation on :node-api-4.0:`InsertOneResult </interfaces/insertoneresult.html>`
+- API Documentation on `insertOne() <{+api+}/classes/collection.html#insertone>`__
+- API Documentation on `InsertOneResult <{+api+}/interfaces/insertoneresult.html>`__
 - Server Manual Entry on :manual:`insertOne() </reference/method/db.collection.insertOne/>`
 - Runnable :doc:`Insert a Document Example </usage-examples/insertOne>`
 
@@ -108,7 +108,7 @@ For example, assume you want to insert the following documents:
 
 If you attempt to insert these documents, a ``WriteError`` occurs at the
 third document and the documents prior to the error get inserted into
-your collection. 
+your collection.
 
 .. note::
 
@@ -116,7 +116,7 @@ your collection.
    processed documents before the error occurs:
 
    .. code-block:: javascript
-      
+
       try {
          const docs = [
             { "_id": 1, "color": "red"},
@@ -124,7 +124,7 @@ your collection.
             { "_id": 1, "color": "yellow"},
             { "_id": 3, "color": "blue"}
          ];
-        
+
          const insertManyresult = await collection.insertMany(docs);
          let ids = insertManyresult.insertedIds;
 
@@ -140,22 +140,22 @@ your collection.
          }
          console.log(`Number of documents inserted: ${e.result.result.nInserted}`);
       }
-   
+
    The output consists of documents MongoDB can process and should look
    something like this:
 
-   .. code-block:: 
+   .. code-block::
       :copyable: false
-      
-      A MongoBulkWriteException occurred, but there are successfully processed documents. 
+
+      A MongoBulkWriteException occurred, but there are successfully processed documents.
       Processed a document with id 1
       Processed a document with id 2
       Processed a document with id 1
       Processed a document with id 3
       Number of documents inserted: 2
-   
+
    If you look inside your collection, you see the following documents:
-   
+
    .. code-block:: json
       :copyable: false
 
@@ -164,13 +164,13 @@ your collection.
 
 On successful insertion, the method returns an
 ``InsertManyResult`` instance representing the number of
-documents inserted and the ``_id`` of the new document. 
+documents inserted and the ``_id`` of the new document.
 
 Example
 ~~~~~~~
 
 The following example creates and adds three documents using the
-``insertMany()`` method: 
+``insertMany()`` method:
 
 .. code-block:: javascript
 
@@ -179,12 +179,12 @@ The following example creates and adds three documents using the
       { name: "New York pizza", shape: "round" },
       { name: "Grandma pizza", shape: "square" }
    ];
-    
+
    const insertManyresult = await collection.insertMany(docs);
    let ids = insertManyresult.insertedIds;
 
    console.log(`${insertManyresult.insertedCount} documents were inserted.`);
-    
+
    for (let id of Object.values(ids)) {
       console.log(`Inserted a document with id ${id}`);
    }
@@ -200,9 +200,9 @@ Your output should look something like this:
    Inserted a document with id 60ca09f4a40cf1d1afcd93a4
 
 For additional information on the classes and methods mentioned in this
-section, see the following resources: 
+section, see the following resources:
 
-- API Documentation on :node-api-4.0:`insertMany() </classes/collection.html#insertmany>`
-- API Documentation on :node-api-4.0:`InsertManyResult </interfaces/insertmanyresult.html>`
+- API Documentation on `insertMany() <{+api+}/classes/collection.html#insertmany>`__
+- API Documentation on `InsertManyResult <{+api+}/interfaces/insertmanyresult.html>`__
 - Server Manual Entry on :manual:`insertMany() </reference/method/db.collection.insertMany/>`
 - Runnable :doc:`Insert Multiple Documents Example </usage-examples/insertMany>`

--- a/source/fundamentals/gridfs.txt
+++ b/source/fundamentals/gridfs.txt
@@ -94,7 +94,7 @@ default name ``fs``, as shown in the following example:
 
    const bucket = new mongodb.GridFSBucket(db, { bucketName: 'myCustomBucket' });
 
-For more information, see the `GridFSBucket API documentation <{+api+}classes/gridfsbucket.html>`__.
+For more information, see the `GridFSBucket API documentation <{+api+}/classes/GridFSBucket.html>`__.
 
 .. _gridfs-upload-files:
 
@@ -117,7 +117,7 @@ following code snippet:
             metadata: { field: 'myField', value: 'myValue' }
         });
 
-See the `openUploadStream() API documentation <{+api+}classes/gridfsbucket.html#openuploadstream>`__ for more information.
+See the `openUploadStream() API documentation <{+api+}/classes/GridFSBucket.html#openUploadStream>`__ for more information.
 
 .. _gridfs-retrieve-file-info:
 
@@ -154,8 +154,8 @@ combined with other methods such as ``sort()``, ``limit()``, and ``project()``.
 For more information on the classes and methods mentioned in this section,
 see the following resources:
 
-- `find() API documentation <{+api+}classes/gridfsbucket.html#find>`__
-- `FindCursor API documentation <{+api+}classes/findcursor.html>`__
+- `find() API documentation <{+api+}/classes/GridFSBucket.html#find>`__
+- `FindCursor API documentation <{+api+}/classes/FindCursor.html>`__
 - :doc:`Cursor Fundamentals page </fundamentals/crud/read-operations/cursor>`
 - :doc:`Read Operations page </fundamentals/crud/read-operations/>`
 
@@ -200,7 +200,7 @@ method, which takes the ``_id`` field of a file as a parameter:
    overhead.
 
 For more information on the ``openDownloadStreamByName()`` method, see
-its `API documentation <{+api+}classes/gridfsbucket.html#opendownloadstreambyname>`__.
+its `API documentation <{+api+}/classes/GridFSBucket.html#openDownloadStreamByName>`__.
 
 .. _gridfs-rename-files:
 

--- a/source/fundamentals/gridfs.txt
+++ b/source/fundamentals/gridfs.txt
@@ -18,7 +18,7 @@ MongoDB using **GridFS**. GridFS is a specification that describes how
 to split files into chunks during storage
 and reassemble them during retrieval. The driver implementation of
 GridFS manages the operations and organization of
-the file storage. 
+the file storage.
 
 You should use GridFS if the size of your file exceeds the BSON-document
 size limit of 16 megabytes. For more detailed information on whether GridFS is
@@ -94,7 +94,7 @@ default name ``fs``, as shown in the following example:
 
    const bucket = new mongodb.GridFSBucket(db, { bucketName: 'myCustomBucket' });
 
-For more information, see the :node-api-4.0:`GridFSBucket API documentation <classes/gridfsbucket.html>`.
+For more information, see the `GridFSBucket API documentation <{+api+}classes/gridfsbucket.html>`__.
 
 .. _gridfs-upload-files:
 
@@ -117,7 +117,7 @@ following code snippet:
             metadata: { field: 'myField', value: 'myValue' }
         });
 
-See the :node-api-4.0:`openUploadStream() API documentation <classes/gridfsbucket.html#openuploadstream>` for more information.
+See the `openUploadStream() API documentation <{+api+}classes/gridfsbucket.html#openuploadstream>`__ for more information.
 
 .. _gridfs-retrieve-file-info:
 
@@ -154,8 +154,8 @@ combined with other methods such as ``sort()``, ``limit()``, and ``project()``.
 For more information on the classes and methods mentioned in this section,
 see the following resources:
 
-- :node-api-4.0:`find() API documentation <classes/gridfsbucket.html#find>`
-- :node-api-4.0:`FindCursor API documentation <classes/findcursor.html>`
+- `find() API documentation <{+api+}classes/gridfsbucket.html#find>`__
+- `FindCursor API documentation <{+api+}classes/findcursor.html>`__
 - :doc:`Cursor Fundamentals page </fundamentals/crud/read-operations/cursor>`
 - :doc:`Read Operations page </fundamentals/crud/read-operations/>`
 
@@ -166,7 +166,7 @@ Download Files
 
 You can download files from your MongoDB database by using the
 ``openDownloadStreamByName()`` method from ``GridFSBucket`` to create a
-download stream. 
+download stream.
 
 The following example shows you how to download a file referenced
 by the file name, stored in the ``filename`` field, into your working
@@ -178,7 +178,7 @@ directory:
         pipe(fs.createWriteStream('./outputFile'));
 
 .. note::
-   
+
    If there are multiple documents with the same ``filename`` value,
    GridFS will stream the most recent file with the given name (as
    determined by the ``uploadDate`` field).
@@ -200,7 +200,7 @@ method, which takes the ``_id`` field of a file as a parameter:
    overhead.
 
 For more information on the ``openDownloadStreamByName()`` method, see
-its :node-api-4.0:`API documentation <classes/gridfsbucket.html#opendownloadstreambyname>`.
+its `API documentation <{+api+}classes/gridfsbucket.html#opendownloadstreambyname>`__.
 
 .. _gridfs-rename-files:
 
@@ -245,7 +245,7 @@ specify the file by its ``_id`` field rather than its file name.
    in separate calls to the ``delete()`` method.
 
 The following example shows you how to delete a file by referencing its ``_id`` field:
- 
+
 .. code-block:: javascript
 
    bucket.delete(ObjectId("60edece5e06275bf0463aaf3"));

--- a/source/fundamentals/promises.txt
+++ b/source/fundamentals/promises.txt
@@ -92,7 +92,7 @@ a ``catch()`` method to the end of a Promise chain.
 
    Certain methods in the driver such as ``find()`` return a ``Cursor``
    instead of a Promise. To determine what type each method returns, refer to
-   the :node-api-4.0:`Node.js API documentation <>`.
+   the `Node.js API documentation <{+api+}>`__.
 
 Await
 ~~~~~
@@ -153,7 +153,7 @@ snippet:
    );
 
 For more information on the callback method signature for the specific
-driver method, see the :node-api-4.0:`API documentation <>`.
+driver method, see the `API documentation <{+api+}>`__.
 
 .. note::
 

--- a/source/fundamentals/typescript.txt
+++ b/source/fundamentals/typescript.txt
@@ -47,8 +47,8 @@ Extend Document
 The following classes accept any type that extends the ``Document``
 interface:
 
-- `Collection <{+api+}classes/collection.html>`__
-- `ChangeStream <{+api+}classes/changestream.html>`__
+- `Collection <{+api+}/classes/Collection.html>`__
+- `ChangeStream <{+api+}/classes/ChangeStream.html>`__
 
 You can pass a type parameter that extends the ``Document`` interface like this:
 
@@ -72,8 +72,8 @@ Any Type
 
 The following classes accept any type parameter:
 
-- `FindCursor <{+api+}classes/findcursor.html>`__
-- `AggregationCursor <{+api+}classes/aggregationcursor.html>`__
+- `FindCursor <{+api+}/classes/FindCursor.html>`__
+- `AggregationCursor <{+api+}/classes/AggregationCursor.html>`__
 
 You can find a code snippet that shows how to specify a type for the ``FindCursor``
 class in the

--- a/source/fundamentals/typescript.txt
+++ b/source/fundamentals/typescript.txt
@@ -18,7 +18,7 @@ of the MongoDB Node.js driver. TypeScript is a strongly typed programming
 language that compiles to JavaScript.
 
 All TypeScript features of the driver are optional. All valid JavaScript
-code written with the driver is also valid TypeScript code. 
+code written with the driver is also valid TypeScript code.
 
 For more information, see the
 `TypeScript website <https://www.typescriptlang.org/>`__.
@@ -38,7 +38,7 @@ All classes that accept a type parameter in the driver have the default type
 
 Any object type can extend the ``Document`` interface.
 
-For more information on object types, see the 
+For more information on object types, see the
 `TypeScript handbook <https://www.typescriptlang.org/docs/handbook/2/objects.html>`__.
 
 Extend Document
@@ -47,8 +47,8 @@ Extend Document
 The following classes accept any type that extends the ``Document``
 interface:
 
-- :node-api-4.0:`Collection <classes/collection.html>`
-- :node-api-4.0:`ChangeStream <classes/changestream.html>`
+- `Collection <{+api+}classes/collection.html>`__
+- `ChangeStream <{+api+}classes/changestream.html>`__
 
 You can pass a type parameter that extends the ``Document`` interface like this:
 
@@ -72,8 +72,8 @@ Any Type
 
 The following classes accept any type parameter:
 
-- :node-api-4.0:`FindCursor <classes/findcursor.html>`
-- :node-api-4.0:`AggregationCursor <classes/aggregationcursor.html>`
+- `FindCursor <{+api+}classes/findcursor.html>`__
+- `AggregationCursor <{+api+}classes/aggregationcursor.html>`__
 
 You can find a code snippet that shows how to specify a type for the ``FindCursor``
 class in the
@@ -92,7 +92,7 @@ Click on the tabs to see code snippets that highlight this behavior:
 
   .. tab:: Dot Notation
      :tabid: dot-notation
-  
+
      The following code snippet does not raise a type error:
 
      .. literalinclude:: /code-snippets/typescript/dot-notation.ts
@@ -103,7 +103,7 @@ Click on the tabs to see code snippets that highlight this behavior:
 
   .. tab:: Nested Objects
      :tabid: nested-objects
-    
+
      The following code snippet raises a type error:
 
      .. literalinclude:: /code-snippets/typescript/dot-notation.ts
@@ -126,7 +126,7 @@ must manually check that your nested field values have your intended type.
 
    In the MongoDB Query Language, you must match a subdocument exactly
    when specifying subdocuments in a query. Dot notation allows you to query
-   nested fields without matching subdocuments exactly.  
+   nested fields without matching subdocuments exactly.
 
    To show this behavior, lets say you have a collection containing
    only the following document:
@@ -145,7 +145,7 @@ must manually check that your nested field values have your intended type.
       :end-before: end-no-doc
 
    The following queries both return your document:
- 
+
    .. literalinclude:: /code-snippets/typescript/note-on-dot-notation.ts
       :language: typescript
       :linenos:

--- a/source/fundamentals/versioned-api.txt
+++ b/source/fundamentals/versioned-api.txt
@@ -85,9 +85,9 @@ following operations:
 For more information on the methods and classes referenced in this
 section, see the following API Documentation:
 
-- :node-api-4.0:`ServerApiVersion </modules.html#serverapiversion>`
-- :node-api-4.0:`MongoClientOptions </interfaces/mongoclientoptions.html>`
-- :node-api-4.0:`MongoClient </classes/mongoclient.html>`
+- `ServerApiVersion <{+api+}/modules.html#serverapiversion>`__
+- `MongoClientOptions <{+api+}/interfaces/mongoclientoptions.html>`__
+- `MongoClient <{+api+}/classes/mongoclient.html>`__
 
 .. _versioned-api-options:
 
@@ -134,4 +134,4 @@ interface.
 For more information on the options in this section, see the following
 API Documentation:
 
-- `ServerApi <{+node-api+}/interfaces/serverapi.html>`__
+- `ServerApi <{+api+}/interfaces/serverapi.html>`__

--- a/source/fundamentals/versioned-api.txt
+++ b/source/fundamentals/versioned-api.txt
@@ -85,9 +85,9 @@ following operations:
 For more information on the methods and classes referenced in this
 section, see the following API Documentation:
 
-- `ServerApiVersion <{+api+}/modules.html#serverapiversion>`__
-- `MongoClientOptions <{+api+}/interfaces/mongoclientoptions.html>`__
-- `MongoClient <{+api+}/classes/mongoclient.html>`__
+- `ServerApiVersion <{+api+}/modules.html#ServerApiVersion>`__
+- `MongoClientOptions <{+api+}/interfaces/MongoClientOptions.html>`__
+- `MongoClient <{+api+}/classes/MongoClient.html>`__
 
 .. _versioned-api-options:
 
@@ -134,4 +134,4 @@ interface.
 For more information on the options in this section, see the following
 API Documentation:
 
-- `ServerApi <{+api+}/interfaces/serverapi.html>`__
+- `ServerApi <{+api+}/interfaces/ServerApi.html>`__

--- a/source/index.txt
+++ b/source/index.txt
@@ -13,7 +13,7 @@ MongoDB Node Driver
   /quick-start
   /usage-examples
   /fundamentals
-  API Documentation <https://mongodb.github.io/node-mongodb-native/4.0/>
+  API Documentation <{+api+}>
   /faq
   /issues-and-help
   /compatibility
@@ -87,7 +87,7 @@ material on using the Node.js driver for the following:
 
 API
 ---
-See the :node-api-4.0:`API documentation <>` if you are looking for
+See the `API documentation <{+api+}>`__ if you are looking for
 technical information about classes, methods, and configuration objects
 within the MongoDB Node.js driver.
 

--- a/source/usage-examples/bulkWrite.txt
+++ b/source/usage-examples/bulkWrite.txt
@@ -9,7 +9,7 @@ Perform Bulk Operations
    do not specify one, this method returns a ``Promise`` that resolves to
    the result object when it completes. See our guide on :doc:`Promises
    and Callbacks </fundamentals/promises>` for more information, or the
-   :node-api-4.0:`API documentation </classes/bulkwriteresult.html>` for information on
+   `API documentation <{+api+}/classes/bulkwriteresult.html>`__ for information on
    the result object.
 
 The ``bulkWrite()`` method performs batch write operations against a
@@ -33,7 +33,7 @@ The ``bulkWrite()`` method accepts the following parameters:
 - ``operations``: specifies the bulk write operations to
   perform. Pass each operation to ``bulkWrite()`` as an object in
   an array. For examples that show the syntax for each write operation, see
-  the :node-api-4.0:`bulkWrite API documentation </classes/collection.html#bulkwrite>`.
+  the `bulkWrite API documentation <{+api+}/classes/collection.html#bulkwrite>`__.
 
 - ``options``: *optional* settings that affect the execution
   of the operation, such as whether the write operations should execute in
@@ -75,20 +75,20 @@ to ``bulkWrite()`` includes examples of ``insertOne``, ``updateMany``, and
 
    .. tab:: JavaScript
       :tabid: javascript
- 
+
       .. literalinclude:: /code-snippets/usage-examples/bulkWrite.js
          :language: javascript
          :linenos:
- 
+
    .. tab:: TypeScript
       :tabid: typescript
- 
+
       .. literalinclude:: /code-snippets/usage-examples/bulkWrite.ts
          :language: typescript
          :linenos:
 
       .. important:: Dot Notation Loses Type Safety
-         
+
          You lose type-safety for values when you use dot notation in keys. For
          more information, see our guide on
          :ref:`TypeScript in the driver <node-driver-typescript-limitations-dot-notation>`.

--- a/source/usage-examples/bulkWrite.txt
+++ b/source/usage-examples/bulkWrite.txt
@@ -9,7 +9,7 @@ Perform Bulk Operations
    do not specify one, this method returns a ``Promise`` that resolves to
    the result object when it completes. See our guide on :doc:`Promises
    and Callbacks </fundamentals/promises>` for more information, or the
-   `API documentation <{+api+}/classes/bulkwriteresult.html>`__ for information on
+   `API documentation <{+api+}/classes/BulkWriteResult.html>`__ for information on
    the result object.
 
 The ``bulkWrite()`` method performs batch write operations against a
@@ -33,7 +33,7 @@ The ``bulkWrite()`` method accepts the following parameters:
 - ``operations``: specifies the bulk write operations to
   perform. Pass each operation to ``bulkWrite()`` as an object in
   an array. For examples that show the syntax for each write operation, see
-  the `bulkWrite API documentation <{+api+}/classes/collection.html#bulkwrite>`__.
+  the `bulkWrite API documentation <{+api+}/classes/Collection.html#bulkWrite>`__.
 
 - ``options``: *optional* settings that affect the execution
   of the operation, such as whether the write operations should execute in

--- a/source/usage-examples/changeStream.txt
+++ b/source/usage-examples/changeStream.txt
@@ -25,7 +25,7 @@ In the example below, the ``$match`` stage will match all change event documents
 The ``watch()`` method accepts an ``options`` object as the second parameter. Refer to the links at the end of this
 section for more information on the settings you can configure with this object.
 
-The ``watch()`` method returns an instance of a :node-api-4.0:`ChangeStream </classes/changestream.html>`. You can read events from
+The ``watch()`` method returns an instance of a `ChangeStream <{+api+}/classes/changestream.html>`__. You can read events from
 change streams by iterating over them or listening for events. Select the tab that corresponds to the way you want to
 read events from the change stream below.
 
@@ -60,7 +60,7 @@ read events from the change stream below.
 
       You can control the change stream by calling ``pause()`` to stop emitting events or ``resume()`` to continue to emit events.
 
-      To stop processing change events, call the :node-api-4.0:`close() </classes/changestream.html#close>` method on the
+      To stop processing change events, call the `close() <{+api+}/classes/changestream.html#close>`__ method on the
       ``ChangeStream`` instance. This closes the change stream and frees resources.
 
       .. code-block:: javascript
@@ -74,10 +74,10 @@ methods presented above:
 - :manual:`Change events </reference/change-events/>`
 - :manual:`Aggregation pipeline </reference/operator/aggregation-pipeline/>`
 - :manual:`Aggregation stages </changeStreams/#modify-change-stream-output>`
-- :node-api-4.0:`ChangeStream class API documentation </classes/changestream.html>`
-- :node-api-4.0:`Collection.watch() </classes/collection.html#watch>`,
-- :node-api-4.0:`Db.watch() </classes/db.html#watch>`,
-- :node-api-4.0:`MongoClient.watch() API documentation </classes/mongoclient.html#watch>`
+- `ChangeStream class API documentation <{+api+}/classes/changestream.html>`__
+- `Collection.watch() <{+api+}/classes/collection.html#watch>`__,
+- `Db.watch() <{+api+}/classes/db.html#watch>`__,
+- `MongoClient.watch() API documentation <{+api+}/classes/mongoclient.html#watch>`__
 
 Example
 -------
@@ -110,14 +110,14 @@ callback process the event before exiting.
 
    .. tab:: JavaScript
       :tabid: javascript
- 
+
       .. literalinclude:: /code-snippets/usage-examples/changeStream.js
          :language: javascript
          :linenos:
- 
+
    .. tab:: TypeScript
       :tabid: typescript
- 
+
       .. literalinclude:: /code-snippets/usage-examples/changeStream.js
          :language: javascript
          :linenos:

--- a/source/usage-examples/changeStream.txt
+++ b/source/usage-examples/changeStream.txt
@@ -25,7 +25,7 @@ In the example below, the ``$match`` stage will match all change event documents
 The ``watch()`` method accepts an ``options`` object as the second parameter. Refer to the links at the end of this
 section for more information on the settings you can configure with this object.
 
-The ``watch()`` method returns an instance of a `ChangeStream <{+api+}/classes/changestream.html>`__. You can read events from
+The ``watch()`` method returns an instance of a `ChangeStream <{+api+}/classes/ChangeStream.html>`__. You can read events from
 change streams by iterating over them or listening for events. Select the tab that corresponds to the way you want to
 read events from the change stream below.
 
@@ -60,7 +60,7 @@ read events from the change stream below.
 
       You can control the change stream by calling ``pause()`` to stop emitting events or ``resume()`` to continue to emit events.
 
-      To stop processing change events, call the `close() <{+api+}/classes/changestream.html#close>`__ method on the
+      To stop processing change events, call the `close() <{+api+}/classes/ChangeStream.html#close>`__ method on the
       ``ChangeStream`` instance. This closes the change stream and frees resources.
 
       .. code-block:: javascript
@@ -74,10 +74,10 @@ methods presented above:
 - :manual:`Change events </reference/change-events/>`
 - :manual:`Aggregation pipeline </reference/operator/aggregation-pipeline/>`
 - :manual:`Aggregation stages </changeStreams/#modify-change-stream-output>`
-- `ChangeStream class API documentation <{+api+}/classes/changestream.html>`__
-- `Collection.watch() <{+api+}/classes/collection.html#watch>`__,
-- `Db.watch() <{+api+}/classes/db.html#watch>`__,
-- `MongoClient.watch() API documentation <{+api+}/classes/mongoclient.html#watch>`__
+- `ChangeStream class API documentation <{+api+}/classes/ChangeStream.html>`__
+- `Collection.watch() <{+api+}/classes/Collection.html#watch>`__,
+- `Db.watch() <{+api+}/classes/Db.html#watch>`__,
+- `MongoClient.watch() API documentation <{+api+}/classes/MongoClient.html#watch>`__
 
 Example
 -------

--- a/source/usage-examples/command.txt
+++ b/source/usage-examples/command.txt
@@ -9,11 +9,11 @@ Run a Command
    not specify one, this method returns a ``Promise`` that resolves to the
    result object when it completes. See our guide on :doc:`Promises and
    Callbacks </fundamentals/promises>` for more information, or the
-   `API documentation <{+api+}/classes/db.html#~resultcallback>`__ for
+   `API documentation <{+api+}/classes/Db.html>`__ for
    information on the result object.
 
 You can run all raw database operations using the
-`db.command() <{+api+}/classes/db.html#~command>`__ method. Call the ``command()`` method with
+`db.command() <{+api+}/classes/Db.html#command>`__ method. Call the ``command()`` method with
 your command object on an instance of a database for diagnostic and
 administrative tasks such as fetching server stats or initializing a replica
 set.
@@ -25,8 +25,8 @@ set.
 You can specify additional options in the ``options`` object passed in
 the second parameter of the ``command()`` method. For more information
 on the options you can pass, see the
-`db.command() API documentation <{+api+}/classes/db.html#~command>`__. You can
-also pass a `callback method <{+api+}/classes/admin.html#~resultcallback>`__ as an
+`db.command() API documentation <{+api+}/classes/Db.html#command>`__. You can
+also pass a `callback method <{+api+}/classes/Admin.html>`__ as an
 optional third parameter.
 
 Example

--- a/source/usage-examples/command.txt
+++ b/source/usage-examples/command.txt
@@ -9,11 +9,11 @@ Run a Command
    not specify one, this method returns a ``Promise`` that resolves to the
    result object when it completes. See our guide on :doc:`Promises and
    Callbacks </fundamentals/promises>` for more information, or the
-   :node-api-4.0:`API documentation </classes/db.html#~resultcallback>` for
+   `API documentation <{+api+}/classes/db.html#~resultcallback>`__ for
    information on the result object.
 
 You can run all raw database operations using the
-:node-api-4.0:`db.command() </classes/db.html#~command>` method. Call the ``command()`` method with
+`db.command() <{+api+}/classes/db.html#~command>`__ method. Call the ``command()`` method with
 your command object on an instance of a database for diagnostic and
 administrative tasks such as fetching server stats or initializing a replica
 set.
@@ -25,8 +25,8 @@ set.
 You can specify additional options in the ``options`` object passed in
 the second parameter of the ``command()`` method. For more information
 on the options you can pass, see the
-:node-api-4.0:`db.command() API documentation </classes/db.html#~command>`. You can
-also pass a :node-api-4.0:`callback method </classes/admin.html#~resultcallback>` as an
+`db.command() API documentation <{+api+}/classes/db.html#~command>`__. You can
+also pass a `callback method <{+api+}/classes/admin.html#~resultcallback>`__ as an
 optional third parameter.
 
 Example

--- a/source/usage-examples/count.txt
+++ b/source/usage-examples/count.txt
@@ -10,18 +10,18 @@ Count Documents
    this method returns a ``Promise`` that resolves to the result object
    when it completes. See our guide on :doc:`Promises and Callbacks
    </fundamentals/promises>` for more information, or the
-   `API documentation <{+api+}/classes/collection.html#~countcallback>`__ for
+   `API documentation <{+api+}/classes/Collection.html#count>`__ for
    information on the result object.
 
 The Node.js driver provides two methods for counting documents in a
 collection:
 
-- `collection.countDocuments() <{+api+}/classes/collection.html#countdocuments>`__ returns the number of documents in
+- `collection.countDocuments() <{+api+}/classes/Collection.html#countDocuments>`__ returns the number of documents in
   the collection that match the specified query. If you specify an empty
   query document, ``countDocuments()`` returns the total number of
   documents in the collection.
 
-- `collection.estimatedDocumentCount() <{+api+}/classes/collection.html#estimateddocumentcount>`__ returns an
+- `collection.estimatedDocumentCount() <{+api+}/classes/Collection.html#estimatedDocumentCount>`__ returns an
   **estimation** of the number of documents in the collection based on
   collection metadata.
 

--- a/source/usage-examples/count.txt
+++ b/source/usage-examples/count.txt
@@ -10,18 +10,18 @@ Count Documents
    this method returns a ``Promise`` that resolves to the result object
    when it completes. See our guide on :doc:`Promises and Callbacks
    </fundamentals/promises>` for more information, or the
-   :node-api-4.0:`API documentation </classes/collection.html#~countcallback>` for
+   `API documentation <{+api+}/classes/collection.html#~countcallback>`__ for
    information on the result object.
 
 The Node.js driver provides two methods for counting documents in a
 collection:
 
-- :node-api-4.0:`collection.countDocuments() </classes/collection.html#countdocuments>` returns the number of documents in
+- `collection.countDocuments() <{+api+}/classes/collection.html#countdocuments>`__ returns the number of documents in
   the collection that match the specified query. If you specify an empty
   query document, ``countDocuments()`` returns the total number of
   documents in the collection.
 
-- :node-api-4.0:`collection.estimatedDocumentCount() </classes/collection.html#estimateddocumentcount>` returns an
+- `collection.estimatedDocumentCount() <{+api+}/classes/collection.html#estimateddocumentcount>`__ returns an
   **estimation** of the number of documents in the collection based on
   collection metadata.
 

--- a/source/usage-examples/deleteMany.txt
+++ b/source/usage-examples/deleteMany.txt
@@ -5,28 +5,28 @@ Delete Multiple Documents
 .. default-domain:: mongodb
 
 .. note::
-   If you specify a callback method, ``deleteMany()`` returns nothing. If you 
+   If you specify a callback method, ``deleteMany()`` returns nothing. If you
    do not specify one, this method returns a ``Promise`` that resolves to the
    result object when it completes. See our guide on :doc:`Promises and
    Callbacks </fundamentals/promises>` for more information, or the
-   :node-api-4.0:`API documentation </classes/collection.html#~deletewriteopresult>` for
+   `API documentation <{+api+}/classes/collection.html#~deletewriteopresult>`__ for
    information on the result object.
 
 You can delete several documents in a collection at once using the
-:node-api-4.0:`collection.deleteMany() </classes/collection.html#deletemany>` method.
+`collection.deleteMany() <{+api+}/classes/collection.html#deletemany>`__ method.
 Pass a query document to the ``deleteMany()`` method to specify a subset
 of documents in the collection to delete. If you do not provide a query
 document (or if you provide an empty document), MongoDB matches all documents
 in the collection and deletes them. While you can use ``deleteMany()``
 to delete all documents in a collection, consider using
-:node-api-4.0:`drop() </classes/collection.html#drop>` instead for better performance
+`drop() <{+api+}/classes/collection.html#drop>`__ instead for better performance
 and clearer code.
 
 You can specify additional options in the ``options`` object passed in
 the second parameter of the ``deleteMany()`` method. You can also pass a
-callback method as the optional third parameter. For more detailed 
-information, see the 
-:node-api-4.0:`deleteMany() API documentation </classes/collection.html#deletemany>`.
+callback method as the optional third parameter. For more detailed
+information, see the
+`deleteMany() API documentation <{+api+}/classes/collection.html#deletemany>`__.
 
 Example
 -------
@@ -41,14 +41,14 @@ match and delete movies with the title "Santa Claus".
 
    .. tab:: JavaScript
       :tabid: javascript
- 
+
       .. literalinclude:: /code-snippets/usage-examples/deleteMany.js
          :language: javascript
          :linenos:
- 
+
    .. tab:: TypeScript
       :tabid: typescript
- 
+
       .. literalinclude:: /code-snippets/usage-examples/deleteMany.ts
          :language: typescript
          :linenos:

--- a/source/usage-examples/deleteMany.txt
+++ b/source/usage-examples/deleteMany.txt
@@ -9,24 +9,24 @@ Delete Multiple Documents
    do not specify one, this method returns a ``Promise`` that resolves to the
    result object when it completes. See our guide on :doc:`Promises and
    Callbacks </fundamentals/promises>` for more information, or the
-   `API documentation <{+api+}/classes/collection.html#~deletewriteopresult>`__ for
+   `API documentation <{+api+}/interfaces/DeleteResult.html>`__ for
    information on the result object.
 
 You can delete several documents in a collection at once using the
-`collection.deleteMany() <{+api+}/classes/collection.html#deletemany>`__ method.
+`collection.deleteMany() <{+api+}/classes/Collection.html#deleteMany>`__ method.
 Pass a query document to the ``deleteMany()`` method to specify a subset
 of documents in the collection to delete. If you do not provide a query
 document (or if you provide an empty document), MongoDB matches all documents
 in the collection and deletes them. While you can use ``deleteMany()``
 to delete all documents in a collection, consider using
-`drop() <{+api+}/classes/collection.html#drop>`__ instead for better performance
+`drop() <{+api+}/classes/Collection.html#drop>`__ instead for better performance
 and clearer code.
 
 You can specify additional options in the ``options`` object passed in
 the second parameter of the ``deleteMany()`` method. You can also pass a
 callback method as the optional third parameter. For more detailed
 information, see the
-`deleteMany() API documentation <{+api+}/classes/collection.html#deletemany>`__.
+`deleteMany() API documentation <{+api+}/classes/Collection.html#deleteMany>`__.
 
 Example
 -------

--- a/source/usage-examples/deleteOne.txt
+++ b/source/usage-examples/deleteOne.txt
@@ -9,7 +9,7 @@ Delete a Document
    do not specify one, this method returns a ``Promise`` that resolves to the
    result object when it completes. See our guide on :doc:`Promises and
    Callbacks </fundamentals/promises>` for more information, or the
-   :node-api-4.0:`API documentation </classes/collection.html#~deletewriteopresult>` for
+   `API documentation <{+api+}/classes/collection.html#~deletewriteopresult>`__ for
    information on the result object.
 
 You can delete a single document in a collection with
@@ -23,16 +23,16 @@ deletes the first match.
 You can specify additional query options using the
 ``options`` object passed as the second parameter of the
 ``deleteOne`` method. You can also pass a
-:node-api-4.0:`callback method </classes/collection.html#~deletewriteopcallback>`
+`callback method <{+api+}/classes/collection.html#~deletewriteopcallback>`__
 as an optional third parameter. For more information on this method,
 see the
-:node-api-4.0:`deleteOne() API documentation </classes/collection.html#deleteone>`.
+`deleteOne() API documentation <{+api+}/classes/collection.html#deleteone>`__.
 
 .. note::
 
   If your application requires the deleted document after deletion,
   consider using the
-  :node-api-4.0:`collection.findOneAndDelete() </classes/collection.html#findoneanddelete>`.
+  `collection.findOneAndDelete() <{+api+}/classes/collection.html#findoneanddelete>`__.
   method, which has a similar interface to ``deleteOne()`` but also
   returns the deleted document.
 

--- a/source/usage-examples/deleteOne.txt
+++ b/source/usage-examples/deleteOne.txt
@@ -9,7 +9,7 @@ Delete a Document
    do not specify one, this method returns a ``Promise`` that resolves to the
    result object when it completes. See our guide on :doc:`Promises and
    Callbacks </fundamentals/promises>` for more information, or the
-   `API documentation <{+api+}/classes/collection.html#~deletewriteopresult>`__ for
+   `API documentation <{+api+}/classes/Collection.html#deleteOne>`__ for
    information on the result object.
 
 You can delete a single document in a collection with
@@ -23,16 +23,16 @@ deletes the first match.
 You can specify additional query options using the
 ``options`` object passed as the second parameter of the
 ``deleteOne`` method. You can also pass a
-`callback method <{+api+}/classes/collection.html#~deletewriteopcallback>`__
+`callback method <{+api+}/classes/Collection.html#deleteOne>`__
 as an optional third parameter. For more information on this method,
 see the
-`deleteOne() API documentation <{+api+}/classes/collection.html#deleteone>`__.
+`deleteOne() API documentation <{+api+}/classes/Collection.html#deleteOne>`__.
 
 .. note::
 
   If your application requires the deleted document after deletion,
   consider using the
-  `collection.findOneAndDelete() <{+api+}/classes/collection.html#findoneanddelete>`__.
+  `collection.findOneAndDelete() <{+api+}/classes/Collection.html#findOneAndDelete>`__.
   method, which has a similar interface to ``deleteOne()`` but also
   returns the deleted document.
 

--- a/source/usage-examples/distinct.txt
+++ b/source/usage-examples/distinct.txt
@@ -9,12 +9,12 @@ Retrieve Distinct Values of a Field
    not specify one, this method returns a ``Promise`` that resolves to the
    result object when it completes. See our guide on :doc:`Promises and
    Callbacks </fundamentals/promises>` for more information, or the
-   :node-api-4.0:`API documentation </classes/collection.html#~resultcallback>` for
+   `API documentation <{+api+}/classes/collection.html#~resultcallback>`__ for
    information on the result object.
 
 You can retrieve a list of distinct values for a field across a
-collection by using the 
-:node-api-4.0:`collection.distinct() </classes/collection.html#distinct>` 
+collection by using the
+`collection.distinct() <{+api+}/classes/collection.html#distinct>`__
 method. Call the ``distinct()`` method
 on a ``Collection`` object with a document field name parameter as a
 ``String`` to produce a list that contains one of each of the different
@@ -36,8 +36,8 @@ a method call to the ``wins`` field in the ``awards`` subdocument:
 
 You can specify additional query options using the ``options`` object passed
 as the third parameter to the ``distinct()`` method. For details on the
-query parameters, see the 
-:node-api-4.0:`distinct() method in the API documentation </classes/collection.html#distinct>`.
+query parameters, see the
+`distinct() method in the API documentation <{+api+}/classes/collection.html#distinct>`__.
 
 If you specify a value for the document field name that is not of type
 ``String`` such as a ``Document``, ``Array``, ``Number``, or ``null``,

--- a/source/usage-examples/distinct.txt
+++ b/source/usage-examples/distinct.txt
@@ -9,12 +9,12 @@ Retrieve Distinct Values of a Field
    not specify one, this method returns a ``Promise`` that resolves to the
    result object when it completes. See our guide on :doc:`Promises and
    Callbacks </fundamentals/promises>` for more information, or the
-   `API documentation <{+api+}/classes/collection.html#~resultcallback>`__ for
+   `API documentation <{+api+}/classes/Collection.html#~resultcallback>`__ for
    information on the result object.
 
 You can retrieve a list of distinct values for a field across a
 collection by using the
-`collection.distinct() <{+api+}/classes/collection.html#distinct>`__
+`collection.distinct() <{+api+}/classes/Collection.html#distinct>`__
 method. Call the ``distinct()`` method
 on a ``Collection`` object with a document field name parameter as a
 ``String`` to produce a list that contains one of each of the different
@@ -37,7 +37,7 @@ a method call to the ``wins`` field in the ``awards`` subdocument:
 You can specify additional query options using the ``options`` object passed
 as the third parameter to the ``distinct()`` method. For details on the
 query parameters, see the
-`distinct() method in the API documentation <{+api+}/classes/collection.html#distinct>`__.
+`distinct() method in the API documentation <{+api+}/classes/Collection.html#distinct>`__.
 
 If you specify a value for the document field name that is not of type
 ``String`` such as a ``Document``, ``Array``, ``Number``, or ``null``,

--- a/source/usage-examples/find.txt
+++ b/source/usage-examples/find.txt
@@ -18,10 +18,10 @@ and
 :doc:`projection </fundamentals/crud/read-operations/project>`
 to configure the result set. You can specify these in the options
 parameter in your ``find()`` method call in ``sort`` and ``projection``
-objects. See `collection.find() <{+api+}/classes/collection.html#find>`__ for more
+objects. See `collection.find() <{+api+}/classes/Collection.html#find>`__ for more
 information on the parameters you can pass to the method.
 
-The ``find()`` method returns a `FindCursor <{+api+}/classes/findcursor.html>`__ that
+The ``find()`` method returns a `FindCursor <{+api+}/classes/FindCursor.html>`__ that
 manages the results of your query. You can iterate through the matching
 documents using one of the following :ref:`cursor methods <cursor-methods>`:
 

--- a/source/usage-examples/find.txt
+++ b/source/usage-examples/find.txt
@@ -18,10 +18,10 @@ and
 :doc:`projection </fundamentals/crud/read-operations/project>`
 to configure the result set. You can specify these in the options
 parameter in your ``find()`` method call in ``sort`` and ``projection``
-objects. See :node-api-4.0:`collection.find() </classes/collection.html#find>` for more
+objects. See `collection.find() <{+api+}/classes/collection.html#find>`__ for more
 information on the parameters you can pass to the method.
 
-The ``find()`` method returns a :node-api-4.0:`FindCursor </classes/findcursor.html>` that
+The ``find()`` method returns a `FindCursor <{+api+}/classes/findcursor.html>`__ that
 manages the results of your query. You can iterate through the matching
 documents using one of the following :ref:`cursor methods <cursor-methods>`:
 

--- a/source/usage-examples/findOne.txt
+++ b/source/usage-examples/findOne.txt
@@ -9,7 +9,7 @@ Find a Document
    not specify one, this method returns a ``Promise`` that resolves to the
    result object when it completes. See our guide on :doc:`Promises and
    Callbacks </fundamentals/promises>` for more information, or the
-   `API documentation <{+api+}/classes/collection.html#~resultcallback>`__ for
+   `API documentation <{+api+}/classes/Collection.html#~resultcallback>`__ for
    information on the result object.
 
 You can query for a single document in a collection with the
@@ -27,7 +27,7 @@ and :doc:`projection </fundamentals/crud/read-operations/project>`
 to configure the returned document. You can specify the additional options
 in the ``options`` object passed as the second parameter of the
 ``findOne`` method. For detailed reference documentation, see
-`collection.findOne() <{+api+}/classes/collection.html#findone>`__.
+`collection.findOne() <{+api+}/classes/Collection.html#findOne>`__.
 
 Example
 -------

--- a/source/usage-examples/findOne.txt
+++ b/source/usage-examples/findOne.txt
@@ -9,7 +9,7 @@ Find a Document
    not specify one, this method returns a ``Promise`` that resolves to the
    result object when it completes. See our guide on :doc:`Promises and
    Callbacks </fundamentals/promises>` for more information, or the
-   :node-api-4.0:`API documentation </classes/collection.html#~resultcallback>` for
+   `API documentation <{+api+}/classes/collection.html#~resultcallback>`__ for
    information on the result object.
 
 You can query for a single document in a collection with the
@@ -27,7 +27,7 @@ and :doc:`projection </fundamentals/crud/read-operations/project>`
 to configure the returned document. You can specify the additional options
 in the ``options`` object passed as the second parameter of the
 ``findOne`` method. For detailed reference documentation, see
-:node-api-4.0:`collection.findOne() </classes/collection.html#findone>`.
+`collection.findOne() <{+api+}/classes/collection.html#findone>`__.
 
 Example
 -------
@@ -60,7 +60,7 @@ collection. It uses the following parameters:
 
   .. tab:: TypeScript
      :tabid: typescript
-    
+
      .. literalinclude:: /code-snippets/usage-examples/findOne.ts
         :language: typescript
 

--- a/source/usage-examples/insertMany.txt
+++ b/source/usage-examples/insertMany.txt
@@ -9,11 +9,11 @@ Insert Multiple Documents
    do not specify one, this method returns a ``Promise`` that resolves to the
    result object when it completes. See our guide on :doc:`Promises and
    Callbacks </fundamentals/promises>` for more information, or the
-   `API documentation <{+api+}/classes/collection.html#~insertwriteopresult>`__ for
+   `API documentation <{+api+}/interfaces/InsertManyResult.html>`__ for
    information on the result object.
 
 You can insert multiple documents using the
-`collection.insertMany() <{+api+}/classes/collection.html#insertmany>`__ method. The ``insertMany()`` takes an array
+`collection.insertMany() <{+api+}/classes/Collection.html#insertMany>`__ method. The ``insertMany()`` takes an array
 of documents to insert into the specified collection.
 
 You can specify additional options in the ``options`` object passed as the

--- a/source/usage-examples/insertMany.txt
+++ b/source/usage-examples/insertMany.txt
@@ -9,11 +9,11 @@ Insert Multiple Documents
    do not specify one, this method returns a ``Promise`` that resolves to the
    result object when it completes. See our guide on :doc:`Promises and
    Callbacks </fundamentals/promises>` for more information, or the
-   :node-api-4.0:`API documentation </classes/collection.html#~insertwriteopresult>` for
+   `API documentation <{+api+}/classes/collection.html#~insertwriteopresult>`__ for
    information on the result object.
 
-You can insert multiple documents using the 
-:node-api-4.0:`collection.insertMany() </classes/collection.html#insertmany>` method. The ``insertMany()`` takes an array
+You can insert multiple documents using the
+`collection.insertMany() <{+api+}/classes/collection.html#insertmany>`__ method. The ``insertMany()`` takes an array
 of documents to insert into the specified collection.
 
 You can specify additional options in the ``options`` object passed as the
@@ -34,14 +34,14 @@ Example
 
    .. tab:: JavaScript
       :tabid: javascript
- 
+
       .. literalinclude:: /code-snippets/usage-examples/insertMany.js
          :language: javascript
          :linenos:
- 
+
    .. tab:: TypeScript
       :tabid: typescript
- 
+
       .. literalinclude:: /code-snippets/usage-examples/insertMany.ts
          :language: typescript
          :linenos:
@@ -50,5 +50,5 @@ If you run the preceding example, you should see the following output:
 
 .. code-block:: none
    :copyable: false
-   
+
    3 documents were inserted

--- a/source/usage-examples/insertOne.txt
+++ b/source/usage-examples/insertOne.txt
@@ -9,21 +9,21 @@ Insert a Document
    do not specify one, this method returns a ``Promise`` that resolves to the
    result object when it completes. See our guide on :doc:`Promises and
    Callbacks </fundamentals/promises>` for more information, or the
-   `API documentation <{+api+}/classes/collection.html#~insertonewriteopresult>`__ for
+   `API documentation <{+api+}/classes/Collection.html#insertOne>`__ for
    information on the result object.
 
 You can insert a document into a collection using the
-`collection.insertOne() <{+api+}/classes/collection.html#insertone>`__ method. To
+`collection.insertOne() <{+api+}/classes/Collection.html#insertOne>`__ method. To
 insert a document, define an object that contains the fields and values that
 you want to store. If the specified collection does not exist, the
 ``insertOne()`` method creates the collection.
 
 You can specify additional query options using the ``options`` parameter.
 For more information on the method parameters, see the
-`insertOne() API documentation <{+api+}/classes/collection.html#insertone>`__. You
+`insertOne() API documentation <{+api+}/classes/Collection.html#insertOne>`__. You
 can also pass a callback method as an optional third parameter.
 For more information on this method, see the
-`insertOne() API documentation <{+api+}/classes/collection.html#insertone>`__.
+`insertOne() API documentation <{+api+}/classes/Collection.html#insertOne>`__.
 
 If the operation successfully inserts a document, it appends an
 ``insertedId`` field to the object passed in the method call, and sets the

--- a/source/usage-examples/insertOne.txt
+++ b/source/usage-examples/insertOne.txt
@@ -6,28 +6,28 @@ Insert a Document
 
 .. note::
    If you specify a callback method, ``insertOne()`` returns nothing. If you
-   do not specify one, this method returns a ``Promise`` that resolves to the 
+   do not specify one, this method returns a ``Promise`` that resolves to the
    result object when it completes. See our guide on :doc:`Promises and
    Callbacks </fundamentals/promises>` for more information, or the
-   :node-api-4.0:`API documentation </classes/collection.html#~insertonewriteopresult>` for
+   `API documentation <{+api+}/classes/collection.html#~insertonewriteopresult>`__ for
    information on the result object.
 
 You can insert a document into a collection using the
-:node-api-4.0:`collection.insertOne() </classes/collection.html#insertone>` method. To
+`collection.insertOne() <{+api+}/classes/collection.html#insertone>`__ method. To
 insert a document, define an object that contains the fields and values that
 you want to store. If the specified collection does not exist, the
 ``insertOne()`` method creates the collection.
 
 You can specify additional query options using the ``options`` parameter.
 For more information on the method parameters, see the
-:node-api-4.0:`insertOne() API documentation </classes/collection.html#insertone>`. You
+`insertOne() API documentation <{+api+}/classes/collection.html#insertone>`__. You
 can also pass a callback method as an optional third parameter.
 For more information on this method, see the
-:node-api-4.0:`insertOne() API documentation </classes/collection.html#insertone>`.
+`insertOne() API documentation <{+api+}/classes/collection.html#insertone>`__.
 
 If the operation successfully inserts a document, it appends an
 ``insertedId`` field to the object passed in the method call, and sets the
-value of the field to the ``_id`` of the inserted document. 
+value of the field to the ``_id`` of the inserted document.
 
 Example
 -------
@@ -38,14 +38,14 @@ Example
 
    .. tab:: JavaScript
       :tabid: javascript
- 
+
       .. literalinclude:: /code-snippets/usage-examples/insertOne.js
          :language: javascript
          :linenos:
- 
+
    .. tab:: TypeScript
       :tabid: typescript
- 
+
       .. literalinclude:: /code-snippets/usage-examples/insertOne.ts
          :language: typescript
          :linenos:

--- a/source/usage-examples/replaceOne.txt
+++ b/source/usage-examples/replaceOne.txt
@@ -9,11 +9,11 @@ Replace a Document
    do not specify one, this method returns a ``Promise`` that resolves to the
    result object when it completes. See our guide on :doc:`Promises and
    Callbacks </fundamentals/promises>` for more information, or the
-   :node-api-4.0:`API documentation </classes/collection.html#~updatewriteopresult>` for
+   `API documentation <{+api+}/classes/collection.html#~updatewriteopresult>`__ for
    information on the result object.
 
 You can replace a single document using the
-:node-api-4.0:`collection.replaceOne() </classes/collection.html#replaceone>` method.
+`collection.replaceOne() <{+api+}/classes/collection.html#replaceone>`__ method.
 ``replaceOne()`` accepts a query document and a replacement document. If
 the query matches a document in the collection, it replaces the first
 document that matches the query with the provided replacement document.
@@ -33,7 +33,7 @@ unique index rule, ``replaceOne()`` throws a ``duplicate key error``.
 .. note::
 
   If your application requires the document after updating,
-  use the :node-api-4.0:`collection.findOneAndReplace() </classes/collection.html#findoneandreplace>`
+  use the `collection.findOneAndReplace() <{+api+}/classes/collection.html#findoneandreplace>`__
   method which has a similar interface to ``replaceOne()``.
   You can configure ``findOneAndReplace()`` to return either the
   original matched document or the replacement document.

--- a/source/usage-examples/replaceOne.txt
+++ b/source/usage-examples/replaceOne.txt
@@ -9,11 +9,11 @@ Replace a Document
    do not specify one, this method returns a ``Promise`` that resolves to the
    result object when it completes. See our guide on :doc:`Promises and
    Callbacks </fundamentals/promises>` for more information, or the
-   `API documentation <{+api+}/classes/collection.html#~updatewriteopresult>`__ for
+   `API documentation <{+api+}/classes/Collection.html#replaceOne>`__ for
    information on the result object.
 
 You can replace a single document using the
-`collection.replaceOne() <{+api+}/classes/collection.html#replaceone>`__ method.
+`collection.replaceOne() <{+api+}/classes/Collection.html#replaceOne>`__ method.
 ``replaceOne()`` accepts a query document and a replacement document. If
 the query matches a document in the collection, it replaces the first
 document that matches the query with the provided replacement document.
@@ -33,7 +33,7 @@ unique index rule, ``replaceOne()`` throws a ``duplicate key error``.
 .. note::
 
   If your application requires the document after updating,
-  use the `collection.findOneAndReplace() <{+api+}/classes/collection.html#findoneandreplace>`__
+  use the `collection.findOneAndReplace() <{+api+}/classes/Collection.html#findOneAndReplace>`__
   method which has a similar interface to ``replaceOne()``.
   You can configure ``findOneAndReplace()`` to return either the
   original matched document or the replacement document.

--- a/source/usage-examples/updateMany.txt
+++ b/source/usage-examples/updateMany.txt
@@ -9,11 +9,11 @@ Update Multiple Documents
    do not specify one, this method returns a ``Promise`` that resolves to the
    result object when it completes. See our guide on :doc:`Promises and
    Callbacks </fundamentals/promises>` for more information, or see the
-   `API documentation <{+api+}/classes/collection.html#~resultcallback>`__ for
+   `API documentation <{+api+}/classes/Collection.html#updateMany>`__ for
    information on the result object.
 
 You can update multiple documents using the
-`collection.updateMany() <{+api+}/classes/collection.html#updatemany>`__ method.
+`collection.updateMany() <{+api+}/classes/Collection.html#updateMany>`__ method.
 The ``updateMany()`` method accepts a filter document and an update document. If the query matches documents in the
 collection, the method applies the updates from the update document to fields
 and values of the matching documents. The update document requires an :manual:`update operator
@@ -22,7 +22,7 @@ and values of the matching documents. The update document requires an :manual:`u
 You can specify additional options in the ``options`` object passed in
 the third parameter of the ``updateMany()`` method. For more detailed
 information, see
-`the updateMany() API documentation <{+api+}/classes/collection.html#updatemany>`__.
+`the updateMany() API documentation <{+api+}/classes/Collection.html#updateMany>`__.
 
 
 Example

--- a/source/usage-examples/updateMany.txt
+++ b/source/usage-examples/updateMany.txt
@@ -9,11 +9,11 @@ Update Multiple Documents
    do not specify one, this method returns a ``Promise`` that resolves to the
    result object when it completes. See our guide on :doc:`Promises and
    Callbacks </fundamentals/promises>` for more information, or see the
-   :node-api-4.0:`API documentation </classes/collection.html#~resultcallback>` for
+   `API documentation <{+api+}/classes/collection.html#~resultcallback>`__ for
    information on the result object.
 
 You can update multiple documents using the
-:node-api-4.0:`collection.updateMany() </classes/collection.html#updatemany>` method.
+`collection.updateMany() <{+api+}/classes/collection.html#updatemany>`__ method.
 The ``updateMany()`` method accepts a filter document and an update document. If the query matches documents in the
 collection, the method applies the updates from the update document to fields
 and values of the matching documents. The update document requires an :manual:`update operator
@@ -21,8 +21,8 @@ and values of the matching documents. The update document requires an :manual:`u
 
 You can specify additional options in the ``options`` object passed in
 the third parameter of the ``updateMany()`` method. For more detailed
-information, see 
-:node-api-4.0:`the updateMany() API documentation </classes/collection.html#updatemany>`.
+information, see
+`the updateMany() API documentation <{+api+}/classes/collection.html#updatemany>`__.
 
 
 Example
@@ -34,14 +34,14 @@ Example
 
    .. tab:: JavaScript
       :tabid: javascript
- 
+
       .. literalinclude:: /code-snippets/usage-examples/updateMany.js
          :language: javascript
          :linenos:
- 
+
    .. tab:: TypeScript
       :tabid: typescript
- 
+
       .. literalinclude:: /code-snippets/usage-examples/updateMany.ts
          :language: typescript
          :linenos:
@@ -52,4 +52,3 @@ If you run the preceding example, you should see the following output:
    :copyable: false
 
    Updated 477 documents
-   

--- a/source/usage-examples/updateOne.txt
+++ b/source/usage-examples/updateOne.txt
@@ -9,11 +9,11 @@ Update a Document
    do not specify one, this method returns a ``Promise`` that resolves to the
    result object when it completes. See our guide on :doc:`Promises and
    Callbacks </fundamentals/promises>` for more information, or see the
-   :node-api-4.0:`API documentation </classes/collection.html#~updatewriteopresult>` for
+   `API documentation <{+api+}/classes/collection.html#~updatewriteopresult>`__ for
    information on the result object.
 
-You can update a single document using the 
-:node-api-4.0:`collection.updateOne() </classes/collection.html#updateone>`
+You can update a single document using the
+`collection.updateOne() <{+api+}/classes/collection.html#updateone>`__
 method. The ``updateOne()`` method accepts a filter
 document and an update document. If the query matches documents in the
 collection, the method applies the updates from the update document to fields
@@ -25,7 +25,7 @@ You can specify additional query options using the ``options`` object
 passed as the second parameter of the ``updateOne()`` method.
 Set the ``upsert`` option to ``true`` to create a new document
 if no documents match the filter. For additional information, see the
-:node-api-4.0:`updateOne() API documentation </classes/collection.html#updateone>`.
+`updateOne() API documentation <{+api+}/classes/collection.html#updateone>`__.
 
 ``updateOne()`` throws an exception if an error occurs during execution.
 If you specify a value in your update document for the immutable field
@@ -36,8 +36,8 @@ key error`` exception.
 .. note::
 
   If your application requires the document after updating,
-  consider using the 
-  :node-api-4.0:`collection.findOneAndUpdate() </classes/collection.html#findoneandupdate>`. 
+  consider using the
+  `collection.findOneAndUpdate() <{+api+}/classes/collection.html#findoneandupdate>`__.
   method, which has a similar
   interface to ``updateOne()`` but also returns the original or updated
   document.
@@ -74,4 +74,3 @@ If you run the example above, you should see the following output:
    :copyable: false
 
    1 document(s) matched the filter, updated 1 document(s)
- 

--- a/source/usage-examples/updateOne.txt
+++ b/source/usage-examples/updateOne.txt
@@ -9,11 +9,11 @@ Update a Document
    do not specify one, this method returns a ``Promise`` that resolves to the
    result object when it completes. See our guide on :doc:`Promises and
    Callbacks </fundamentals/promises>` for more information, or see the
-   `API documentation <{+api+}/classes/collection.html#~updatewriteopresult>`__ for
+   `API documentation <{+api+}/classes/Collection.html#updateOne>`__ for
    information on the result object.
 
 You can update a single document using the
-`collection.updateOne() <{+api+}/classes/collection.html#updateone>`__
+`collection.updateOne() <{+api+}/classes/Collection.html#updateOne>`__
 method. The ``updateOne()`` method accepts a filter
 document and an update document. If the query matches documents in the
 collection, the method applies the updates from the update document to fields
@@ -25,7 +25,7 @@ You can specify additional query options using the ``options`` object
 passed as the second parameter of the ``updateOne()`` method.
 Set the ``upsert`` option to ``true`` to create a new document
 if no documents match the filter. For additional information, see the
-`updateOne() API documentation <{+api+}/classes/collection.html#updateone>`__.
+`updateOne() API documentation <{+api+}/classes/Collection.html#updateOne>`__.
 
 ``updateOne()`` throws an exception if an error occurs during execution.
 If you specify a value in your update document for the immutable field
@@ -37,7 +37,7 @@ key error`` exception.
 
   If your application requires the document after updating,
   consider using the
-  `collection.findOneAndUpdate() <{+api+}/classes/collection.html#findoneandupdate>`__.
+  `collection.findOneAndUpdate() <{+api+}/classes/Collection.html#findOneAndUpdate>`__.
   method, which has a similar
   interface to ``updateOne()`` but also returns the original or updated
   document.

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -183,7 +183,7 @@ operator instead.
 Authentication
 ++++++++++++++
 
-- ``gssapiServiceName`` is now removed. Use :node-api-4.0:`authMechanismProperties.SERVICE_NAME <interfaces/mongoclientoptions.html#authmechanismproperties>` in the URI or as an option on ``MongoClientOptions``.
+- ``gssapiServiceName`` is now removed. Use `authMechanismProperties.SERVICE_NAME <{+api+}interfaces/mongoclientoptions.html#authmechanismproperties>`__ in the URI or as an option on ``MongoClientOptions``.
 
   .. example::
 
@@ -309,7 +309,7 @@ Unified Topology
 
 - It is longer required to specify ``useUnifiedTopology`` or ``useNewUrlParser``.
 
-- You must use the new ``directConnection`` :node-api-4.0:`option <interfaces/mongoclientoptions.html#directconnection>`
+- You must use the new ``directConnection`` `option <{+api+}interfaces/mongoclientoptions.html#directconnection>`__
   to connect to unitiliazed replica set members.
 
 Explain
@@ -342,7 +342,7 @@ New features of the 3.6 Node.js driver release include:
 
 - Added support for the :ref:`MONGODB-AWS <mongodb-aws>` authentication mechanism using Amazon Web Services (AWS) Identity and Access Management (IAM) credentials
 - Added support for Online Certificate Status Protocol (OCSP)
-- The :node-api-4.0:`find() <classes/collection.html#find>` method supports ``allowDiskUse()`` for sorts that require too much memory to execute in RAM
+- The `find() <{+api+}classes/collection.html#find>`__ method supports ``allowDiskUse()`` for sorts that require too much memory to execute in RAM
 - The :ref:`update() <updateDocuments>` and :ref:`replaceOne() <replacementDocument>` methods support index hints
 - A reduction in recovery time for topology changes and failover events
 - Improvements in validation testing for the default :manual:`writeConcern </reference/write-concern/>`

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -183,7 +183,7 @@ operator instead.
 Authentication
 ++++++++++++++
 
-- ``gssapiServiceName`` is now removed. Use `authMechanismProperties.SERVICE_NAME <{+api+}interfaces/mongoclientoptions.html#authmechanismproperties>`__ in the URI or as an option on ``MongoClientOptions``.
+- ``gssapiServiceName`` is now removed. Use `authMechanismProperties.SERVICE_NAME <{+api+}/interfaces/MongoClientOptions.html#authMechanismProperties>`__ in the URI or as an option on ``MongoClientOptions``.
 
   .. example::
 
@@ -309,7 +309,7 @@ Unified Topology
 
 - It is longer required to specify ``useUnifiedTopology`` or ``useNewUrlParser``.
 
-- You must use the new ``directConnection`` `option <{+api+}interfaces/mongoclientoptions.html#directconnection>`__
+- You must use the new ``directConnection`` `option <{+api+}/interfaces/MongoClientOptions.html#directConnection>`__
   to connect to unitiliazed replica set members.
 
 Explain
@@ -342,7 +342,7 @@ New features of the 3.6 Node.js driver release include:
 
 - Added support for the :ref:`MONGODB-AWS <mongodb-aws>` authentication mechanism using Amazon Web Services (AWS) Identity and Access Management (IAM) credentials
 - Added support for Online Certificate Status Protocol (OCSP)
-- The `find() <{+api+}classes/collection.html#find>`__ method supports ``allowDiskUse()`` for sorts that require too much memory to execute in RAM
+- The `find() <{+api+}/classes/Collection.html#find>`__ method supports ``allowDiskUse()`` for sorts that require too much memory to execute in RAM
 - The :ref:`update() <updateDocuments>` and :ref:`replaceOne() <replacementDocument>` methods support index hints
 - A reduction in recovery time for topology changes and failover events
 - Improvements in validation testing for the default :manual:`writeConcern </reference/write-concern/>`


### PR DESCRIPTION
## Pull Request Info

This PR changes the API links to use source constants and camelCases them.

`rg -o '\{\+api\+\}\w.*\.html(#\w+)?' .` returns no results (checks for `{+api}+/<lowercase letter followed by standard link format>`

Manual checking of every changed link also ensured anchor targets are correct. Even though modules/classes/interfaces begin with a capital letter and are camel-cased, options are camel-cased but beginning with a lowercase letter

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-18513

### Snooty build log:

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=613780be7dcf01293077b2ac

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodborg-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-18513/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
