### PR TITLE
DOCSP-18158 updated change stream example

### DIFF
--- a/source/code-snippets/usage-examples/changeStream.js
+++ b/source/code-snippets/usage-examples/changeStream.js
@@ -14,11 +14,11 @@ let changeStream;
 async function run() {
   try {
     await client.connect();
-    const database = client.db("sample_mflix");
-    const movies = database.collection("movies");
+    const database = client.db("insertDB");
+    const collection = database.collection("haikus");
 
-    // open a Change Stream on the "movies" collection
-    changeStream = movies.watch();
+    // open a Change Stream on the "haikus" collection
+    changeStream = collection.watch();
 
     // set up a listener when change events are emitted
     changeStream.on("change", next => {
@@ -28,13 +28,16 @@ async function run() {
 
     await simulateAsyncPause();
 
-    await movies.insertOne({
-      test: "sample movie document"
+    await collection.insertOne({
+      title: "Record of a Shriveled Datum",
+      content: "No bytes, no problem. Just insert a document, in MongoDB",
     });
 
     await simulateAsyncPause();
 
-    await changeStream.close(() => console.log("closed the change stream"));
+    await changeStream.close();
+    
+    console.log("closed the change stream");
   } finally {
     await client.close();
   }

--- a/source/code-snippets/usage-examples/changeStream.js
+++ b/source/code-snippets/usage-examples/changeStream.js
@@ -14,27 +14,27 @@ let changeStream;
 async function run() {
   try {
     await client.connect();
-    const database = client.db('sample_mflix');
-    const movies = database.collection('movies');
+    const database = client.db("sample_mflix");
+    const movies = database.collection("movies");
 
     // open a Change Stream on the "movies" collection
     changeStream = movies.watch();
 
     // set up a listener when change events are emitted
-    changeStream.on('change', next => {
+    changeStream.on("change", next => {
       // process any change event
-      console.log('received a change to the collection: \t', next);
+      console.log("received a change to the collection: \t", next);
     });
 
     await simulateAsyncPause();
 
     await movies.insertOne({
-      test: 'sample movie document'
+      test: "sample movie document"
     });
 
     await simulateAsyncPause();
 
-    await changeStream.close(() => console.log('closed the change stream'));
+    await changeStream.close(() => console.log("closed the change stream"));
   } finally {
     await client.close();
   }

--- a/source/code-snippets/usage-examples/changeStream.js
+++ b/source/code-snippets/usage-examples/changeStream.js
@@ -7,7 +7,7 @@ const client = new MongoClient(uri);
 
 const simulateAsyncPause = () =>
   new Promise(resolve => {
-    setTimeout(() => resolve(), 100);
+    setTimeout(() => resolve(), 1000);
   });
 
 let changeStream;

--- a/source/code-snippets/usage-examples/changeStream.js
+++ b/source/code-snippets/usage-examples/changeStream.js
@@ -5,37 +5,30 @@ const uri = "<connection string uri>";
 
 const client = new MongoClient(uri);
 
+const simulateAsyncPause = () =>
+  new Promise(resolve => {
+    setTimeout(() => resolve(), 20000);
+  });
+
 let changeStream;
 async function run() {
   try {
     await client.connect();
-    const database = client.db("sample_mflix");
-    const movies = database.collection("movies");
+    const database = client.db('insert_db');
+    const movies = database.collection('haiku');
 
-    // open a Change Stream on the "movies" collection
+    // open a Change Stream on the "haiku" collection
     changeStream = movies.watch();
 
     // set up a listener when change events are emitted
-    changeStream.on("change", next => {
+    changeStream.on('change', next => {
       // process any change event
-      console.log("received a change to the collection: \t", next);
+      console.log('received a change to the collection: \t', next);
     });
 
-    // use a timeout to ensure the listener is registered before the insertOne
-    // operation is called.
-    await new Promise(resolve => {
-      setTimeout(async () => {
-        await movies.insertOne({
-          test: "sample movie document",
-        });
-        // wait to close `changeStream` after the listener receives the event
-        setTimeout(async () => {
-          resolve(
-            await changeStream.close(() => console.log("closed the change stream"))
-          );
-        }, 1000);
-      }, 1000);
-    });
+    await simulateAsyncPause();
+
+    await changeStream.close(() => console.log('closed the change stream'));
   } finally {
     await client.close();
   }

--- a/source/code-snippets/usage-examples/changeStream.js
+++ b/source/code-snippets/usage-examples/changeStream.js
@@ -7,23 +7,29 @@ const client = new MongoClient(uri);
 
 const simulateAsyncPause = () =>
   new Promise(resolve => {
-    setTimeout(() => resolve(), 20000);
+    setTimeout(() => resolve(), 100);
   });
 
 let changeStream;
 async function run() {
   try {
     await client.connect();
-    const database = client.db('insert_db');
-    const movies = database.collection('haiku');
+    const database = client.db('sample_mflix');
+    const movies = database.collection('movies');
 
-    // open a Change Stream on the "haiku" collection
+    // open a Change Stream on the "movies" collection
     changeStream = movies.watch();
 
     // set up a listener when change events are emitted
     changeStream.on('change', next => {
       // process any change event
       console.log('received a change to the collection: \t', next);
+    });
+
+    await simulateAsyncPause();
+
+    await movies.insertOne({
+      test: 'sample movie document'
     });
 
     await simulateAsyncPause();

--- a/source/usage-examples/changeStream.txt
+++ b/source/usage-examples/changeStream.txt
@@ -88,16 +88,16 @@ print change events that occur on the collection.
 
 First, open the change stream on the collection and then define a callback
 on the change stream using the ``on()`` method. Once set, generate a change
-event to emit by performing a change to the collection.
+event by performing a change to the collection.
 
 To generate the change event on the collection, let's use ``insertOne()``
 method to add a new document. Since the ``insertOne()`` may run before the
-listener function can register, we use a timer, declared with
-``simulateAsyncPause`` to wait 100 milliseconds before executing the insert.
+listener function can register, we use a timer, defined as
+``simulateAsyncPause`` to wait 1 second before executing the insert.
 
 We also use ``simulateAsyncPause`` after the insertion of the document
 to provide ample time for the listener function to receive the change
-event and the for the callback to complete its execution before 
+event and for the callback to complete its execution before 
 closing the ``ChangeStream`` instance using the ``close()`` method.
 
 The timers used in this example are only necessary for this demonstration

--- a/source/usage-examples/changeStream.txt
+++ b/source/usage-examples/changeStream.txt
@@ -82,8 +82,8 @@ methods presented above:
 Example
 -------
 
-The following example opens a change stream on the ``movies`` collection in
-the ``sample_mflix`` database. Let's create a listener function to receive and
+The following example opens a change stream on the ``haikus`` collection in
+the ``insertDB`` database. Let's create a listener function to receive and
 print change events that occur on the collection.
 
 First, open the change stream on the collection and then define a callback
@@ -136,8 +136,8 @@ If you run the preceding example, you should see the following output:
      _id: { _data: '825EC...' },
      operationType: 'insert',
      clusterTime: new Timestamp { ... },
-     fullDocument: { _id: new ObjectId(...), test: 'sample movie document' },
-     ns: { db: 'sample_mflix', coll: 'movies' },
+     fullDocument: { _id: new ObjectId(...), title: 'Record of a Shriveled Datum', content: 'No bytes, no problem. Just insert a document, in MongoDB' },
+     ns: { db: 'insertDB', coll: 'haikus' },
      documentKey: { _id: new ObjectId(...) }
    }
    closed the change stream

--- a/source/usage-examples/changeStream.txt
+++ b/source/usage-examples/changeStream.txt
@@ -14,7 +14,7 @@ change stream emits **change event** documents when they occur.
 The ``watch()`` method optionally takes an **aggregation pipeline** which consists of an array of **aggregation stages**
 as the first parameter. The aggregation stages filter and transform the change events.
 
-In the following snippet, the ``$match`` stage will match all change event documents with a ``runtime`` value of less than
+In the following snippet, the ``$match`` stage matches all change event documents with a ``runtime`` value of less than
 15, filtering all others out.
 
 .. code-block:: javascript
@@ -82,26 +82,27 @@ methods presented above:
 Example
 -------
 
-The following example opens a change stream on the ``haiku`` collection in
-the ``insert_db`` database. Let's create a listener function to receive and
+The following example opens a change stream on the ``movies`` collection in
+the ``sample_mflix`` database. Let's create a listener function to receive and
 print change events that occur on the collection.
 
 First, open the change stream on the collection and then define a callback
-on the change stream using the ``on()`` method. Once set, generate the
-change event on the collection, run the :doc:`insert a document usage
-example <insertOne>` in a different shell.
+on the change stream using the ``on()`` method. Once set, generate a change
+event to emit by performing a change to the collection.
 
-Since it may take some time for the listener function pick up the change
-event, we use a timer. We define the timer with ``simulateAsyncPause``
-to wait 20 seconds before closing the ``ChangeStream`` instance using
-the ``close()`` method.
+To generate the change event on the collection, let's use ``insertOne()``
+method to add a new document. Since the ``insertOne()`` may run before the
+listener function can register, we use a timer, declared with
+``simulateAsyncPause`` to wait 100 milliseconds before executing the insert.
 
-.. note::
+We also use ``simulateAsyncPause`` after the insertion of the document
+to provide ample time for the listener function to receive the change
+event and the for the callback to complete its execution before 
+closing the ``ChangeStream`` instance using the ``close()`` method.
 
-   The timer used in this example is only necessary for this demonstration
-   to make sure there is enough time to pick up the change event before
-   exiting. If you need more or less time, modify the
-   ``simulateAsyncPause`` declaration.
+The timers used in this example are only necessary for this demonstration
+to make sure there is enough time to register listener and have the
+callback process the event before exiting.
 
 .. include:: /includes/connect-guide-note.rst
 
@@ -132,19 +133,14 @@ If you run the preceding example, you should see the following output:
    :copyable: false
 
    received a change to the collection: 	 {
-      _id: {
-         _data: '8261...'
-      },
-      operationType: 'insert',
-      clusterTime: new Timestamp({ t: 1631216117, i: 9 }),
-      fullDocument: {
-         _id: new ObjectId("..."),
-         title: 'Record of a Shriveled Datum',
-         content: 'No bytes, no problem. Just insert a document, in MongoDB'
-      },
-      ns: { db: 'insert_db', coll: 'haiku' },
-      documentKey: { _id: new ObjectId("...") }
-      }
+     _id: { _data: '825EC...' },
+     operationType: 'insert',
+     clusterTime: new Timestamp { ... },
+     fullDocument: { _id: new ObjectId(...), test: 'sample movie document' },
+     ns: { db: 'sample_mflix', coll: 'movies' },
+     documentKey: { _id: new ObjectId(...) }
+   }
+   closed the change stream
 
 .. note:: Receive Full Documents From Updates
 

--- a/source/usage-examples/changeStream.txt
+++ b/source/usage-examples/changeStream.txt
@@ -14,7 +14,7 @@ change stream emits **change event** documents when they occur.
 The ``watch()`` method optionally takes an **aggregation pipeline** which consists of an array of **aggregation stages**
 as the first parameter. The aggregation stages filter and transform the change events.
 
-In the example below, the ``$match`` stage will match all change event documents with a ``runtime`` value of less than
+In the following snippet, the ``$match`` stage will match all change event documents with a ``runtime`` value of less than
 15, filtering all others out.
 
 .. code-block:: javascript
@@ -82,27 +82,26 @@ methods presented above:
 Example
 -------
 
-The following example opens a change stream on the ``movies`` collection in
-the ``sample_mflix`` database. Let's create a listener function to receive and
+The following example opens a change stream on the ``haiku`` collection in
+the ``insert_db`` database. Let's create a listener function to receive and
 print change events that occur on the collection.
 
 First, open the change stream on the collection and then define a callback
-on the change stream using the ``on()`` method. Once set, generate a change
-event to be emitted by performing a change to the collection.
+on the change stream using the ``on()`` method. Once set, generate the
+change event on the collection, run the :doc:`insert a document usage
+example <insertOne>` in a different shell.
 
-To generate the change event on the collection, let's use ``insertOne()``
-method to add a new document. Since the ``insertOne()`` may run before the
-listener function can register, we use a timer, declared with ``setTimeout()``
-to wait one second before executing the insert.
+Since it may take some time for the listener function pick up the change
+event, we use a timer. We define the timer with ``simulateAsyncPause``
+to wait 20 seconds before closing the ``ChangeStream`` instance using
+the ``close()`` method.
 
-We also use a second timer to wait an additional second after the insertion of
-the document to provide ample time for the change event to be received and
-the for the callback to complete its execution before closing the
-``ChangeStream`` instance using the ``close()`` method.
+.. note::
 
-The timers used in this example are only necessary for this demonstration
-to make sure there is enough time to register listener and have the
-callback process the event before exiting.
+   The timer used in this example is only necessary for this demonstration
+   to make sure there is enough time to pick up the change event before
+   exiting. If you need more or less time, modify the
+   ``simulateAsyncPause`` declaration.
 
 .. include:: /includes/connect-guide-note.rst
 
@@ -133,16 +132,19 @@ If you run the preceding example, you should see the following output:
    :copyable: false
 
    received a change to the collection: 	 {
-     _id: {
-       _data: '825EC...'
-     },
-     operationType: 'insert',
-     clusterTime: Timestamp { ... },
-     fullDocument: { _id: 5ec3..., test: 'sample movie document' },
-     ns: { db: 'sample_mflix', coll: 'movies' },
-     documentKey: { _id: 5ec3... },
-   }
-   closed the change stream
+      _id: {
+         _data: '8261...'
+      },
+      operationType: 'insert',
+      clusterTime: new Timestamp({ t: 1631216117, i: 9 }),
+      fullDocument: {
+         _id: new ObjectId("..."),
+         title: 'Record of a Shriveled Datum',
+         content: 'No bytes, no problem. Just insert a document, in MongoDB'
+      },
+      ns: { db: 'insert_db', coll: 'haiku' },
+      documentKey: { _id: new ObjectId("...") }
+      }
 
 .. note:: Receive Full Documents From Updates
 


### PR DESCRIPTION
## Pull Request Info
Updated the watch for changes usage example to be more natural -- I spoke to Daria and she provided me a snippet to replace the current one with.

This will be cherry-picked across all the pages since its the same page for all.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-18158

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=61410b4dc608bec57ff3c51a

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-18158-WatchUsageExampleUpdate/usage-examples/changeStream/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [x] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [x] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
