### PR TITLE
fix constant name

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -7,5 +7,5 @@ toc_landing_pages = ["/fundamentals/authentication", "/fundamentals", "/fundamen
 version = 4.1
 package-name-org = "mongodb-org"
 pgp-version = "{+version+}"
-node-api = "https://mongodb.github.io/node-mongodb-native/{+version+}"
+api = "https://mongodb.github.io/node-mongodb-native/{+version+}"
 mongosh = "``mongosh``"


### PR DESCRIPTION
## Pull Request Info

Fix constant name which was incorrectly handled in merge. I accidentally [overwrote Nathan's renaming of this constant in this PR](https://github.com/mongodb/docs-node/commit/3e6321a823bbd146e899b2cac5e0ad037ce006d6)

### Issue JIRA link:

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=613a783ec608bec57fe78dd0

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodborg-staging.corp.mongodb.com/node/docsworker-xlarge/fix-incorrect-merge/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Does it render on staging correctly?
- [ ] Are all the links working?
- [ ] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
