### PR TITLE
DOCSP-18838: fix broken links

### DIFF
--- a/source/fundamentals/authentication/mechanisms.txt
+++ b/source/fundamentals/authentication/mechanisms.txt
@@ -63,7 +63,7 @@ algorithm to authenticate your user.
 
 You can specify this authentication mechanism by setting the ``authMechanism``
 to the value ``SCRAM-SHA-256`` in the
-:manual:`connection string <reference/connection-string/>` as shown in the
+:manual:`connection string </reference/connection-string/>` as shown in the
 following sample code.
 
 .. important::

--- a/source/fundamentals/connection.txt
+++ b/source/fundamentals/connection.txt
@@ -107,13 +107,17 @@ When making a connection, the driver takes the following actions by default:
 Direct Connection
 +++++++++++++++++
 
-To force operations on the host designated in the connection URI, specify the ``directConnection`` option. Direct
-connections:
+To force your operations to run on the host specified in your connection
+URI, you can specify the ``directConnection`` connection option. If you
+specify this option, you must use the standard connection URI format. The
+driver does not accept the DNS seedlist connection format (SRV) when you
+specify this option.
 
-- Don't support SRV strings.
-- Fails on writes when the specified host is not the **primary**.
-- Require :manual:`enabling secondary reads </reference/method/rs.secondaryOk/>`
-   when the specified host isn't the **primary**.
+If you specify the ``directConnection`` and a specify a secondary member
+of the replica set, your write operations fail because it is not the
+primary member. To perform read operations, you must enable secondary reads.
+See the :manual:`read preference options </reference/connection-string/#read-preference-options>`
+for more information.
 
 .. _connection-options:
 

--- a/source/fundamentals/connection.txt
+++ b/source/fundamentals/connection.txt
@@ -113,10 +113,10 @@ specify this option, you must use the standard connection URI format. The
 driver does not accept the DNS seedlist connection format (SRV) when you
 specify this option.
 
-If you specify the ``directConnection`` and a specify a secondary member
-of the replica set, your write operations fail because it is not the
-primary member. To perform read operations, you must enable secondary reads.
-See the :manual:`read preference options </reference/connection-string/#read-preference-options>`
+When you specify ``directConnection`` and connect to a secondary member of the 
+replica set, your write operations fail because it is not the primary member.
+To perform read operations, you must enable secondary reads. See the 
+:manual:`read preference options </reference/connection-string/#read-preference-options>`
 for more information.
 
 .. _connection-options:

--- a/source/fundamentals/connection.txt
+++ b/source/fundamentals/connection.txt
@@ -105,7 +105,7 @@ When making a connection, the driver takes the following actions by default:
    is unavailable, provide the full list of hosts.
 
 Direct Connection
-+++++++++++++++++
+^^^^^^^^^^^^^^^^^
 
 To force your operations to run on the host specified in your connection
 URI, you can specify the ``directConnection`` connection option. If you


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-18838

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=614e84a8bc80a0834ba3a0c9

### Docs staging link (requires sign-in on MongoDB Corp SSO):
[Direct Connection](https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-18838-broken-link-fix/fundamentals/connection/#direct-connection)

[SCRAM SHA-256](https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-18838-broken-link-fix/fundamentals/authentication/mechanisms/#scram-sha-256)


 
### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
