### PR TITLE
About compat tables

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -2,6 +2,7 @@ name = "node"
 title = "Node.js"
 
 toc_landing_pages = ["/fundamentals/authentication", "/fundamentals", "/fundamentals/crud", "/usage-examples"]
+sharedinclude_root = "https://raw.githubusercontent.com/10gen/docs-shared/main/"
 
 [constants]
 version = 4.1
@@ -9,3 +10,4 @@ package-name-org = "mongodb-org"
 pgp-version = "{+version+}"
 api = "https://mongodb.github.io/node-mongodb-native/{+version+}"
 mongosh = "``mongosh``"
+driver = "node"

--- a/source/compatibility.txt
+++ b/source/compatibility.txt
@@ -9,12 +9,12 @@ Compatibility
 =============
 
 MongoDB Compatibility
-~~~~~~~~~~~~~~~~~~~~~
+---------------------
 
 .. include:: /includes/mongodb-compatibility-table-node.rst
 
 Language Compatibility
-~~~~~~~~~~~~~~~~~~~~~~
+----------------------
 
 .. include:: /includes/language-compatibility-table-node.rst
 

--- a/source/compatibility.txt
+++ b/source/compatibility.txt
@@ -10,3 +10,6 @@ Language Compatibility
 ~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: /includes/language-compatibility-table-node.rst
+
+
+.. sharedinclude:: dbx/about-compatibility.rst

--- a/source/compatibility.txt
+++ b/source/compatibility.txt
@@ -11,10 +11,14 @@ Compatibility
 MongoDB Compatibility
 ---------------------
 
+:ref:`mongodb-compatibility-table-about-node`
+
 .. include:: /includes/mongodb-compatibility-table-node.rst
 
 Language Compatibility
 ----------------------
+
+:ref:`language-compatibility-table-about-node`
 
 .. include:: /includes/language-compatibility-table-node.rst
 

--- a/source/compatibility.txt
+++ b/source/compatibility.txt
@@ -11,14 +11,14 @@ Compatibility
 MongoDB Compatibility
 ---------------------
 
-:ref:`mongodb-compatibility-table-about-node`
+:ref:`What information does the MongoDB Compatibility table show? <mongodb-compatibility-table-about-node>`
 
 .. include:: /includes/mongodb-compatibility-table-node.rst
 
 Language Compatibility
 ----------------------
 
-:ref:`language-compatibility-table-about-node`
+:ref:`What information does the Language Compatibility table show? <language-compatibility-table-about-node>`
 
 .. include:: /includes/language-compatibility-table-node.rst
 

--- a/source/compatibility.txt
+++ b/source/compatibility.txt
@@ -17,5 +17,7 @@ Language Compatibility
 
 .. include:: /includes/language-compatibility-table-node.rst
 
+About Compatibility Tables
+--------------------------
 
 .. sharedinclude:: dbx/about-compatibility.rst

--- a/source/compatibility.txt
+++ b/source/compatibility.txt
@@ -1,7 +1,7 @@
 .. contents:: On this page
    :local:
    :backlinks: none
-   :depth: 2
+   :depth: 1
    :class: singlecol
 
 Compatibility

--- a/source/compatibility.txt
+++ b/source/compatibility.txt
@@ -1,3 +1,9 @@
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
 Compatibility
 -------------
 

--- a/source/compatibility.txt
+++ b/source/compatibility.txt
@@ -1,11 +1,12 @@
 .. contents:: On this page
    :local:
    :backlinks: none
-   :depth: 1
+   :depth: 2
    :class: singlecol
 
+=============
 Compatibility
--------------
+=============
 
 MongoDB Compatibility
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Pull Request Info

This adds information about compatibility tables to the page. It uses shareable content so that the content can be used across all driver sites.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-19453

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=6189c9c4c13055282d2e5cc8

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-19453/compatibility/#mongodb-compatibility-table
### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
