### PR TITLE
DOCSP-20056: UTF-8 validation options

### DIFF
--- a/source/fundamentals.txt
+++ b/source/fundamentals.txt
@@ -19,5 +19,6 @@ Fundamentals
    /fundamentals/gridfs
    /fundamentals/time-series
    /fundamentals/typescript
+   /fundamentals/utf8-validation
 
 .. include:: /includes/fundamentals-sections.rst

--- a/source/fundamentals/utf8-validation.txt
+++ b/source/fundamentals/utf8-validation.txt
@@ -16,30 +16,32 @@ Overview
 --------
 
 In this guide, you can learn how to enable or disable the {+driver-short+}'s
-**UTF-8** validation feature. **UTF-8** is a character encoding specification
+**UTF-8** validation feature. UTF-8 is a character encoding specification
 that ensures compatibility and consistent presentation across most operating
-systems, applications, and language character sets. By default, the driver
-checks documents for any characters that are not encoded in a valid UTF-8
-format when it transfers data between your application and MongoDB.
+systems, applications, and language character sets.
 
-If you enable validation, the driver substitutes invalid UTF-8 characters
-with valid UTF-8 ones when transferring data between your application and
-MongoDB. The validation adds processing overhead since it needs to verify the
-data and to make substitutions when necessary.
+If you *enable* validation, the driver throws an error when it attempts to
+convert data that contains invalid UTF-8 characters. The validation adds
+processing overhead since it needs to check the data.
 
-If you disable validation, your application can avoid the processing
-overhead caused by validation, but cannot guarantee consistent presentation of
-invalid UTF-8 data.
+If you *disable* validation, your application avoids the validation processing
+overhead, but cannot guarantee consistent presentation of invalid UTF-8 data.
 
-Read the sections below to learn how to set UTF-8 validation using the
-{+driver-short+}.
+The driver enables UTF-8 validation by default. It checks documents for any
+characters that are not encoded in a valid UTF-8 format when it transfers data
+between your application. If it encounters invalid UTF-8 characters, it
+throws an error.
 
 .. note::
 
-   The {+driver-short+} automatically substitutes invalid UTF-8 characters
-   in your application before sending them to MongoDB regardless of whether
-   you enable validation. You can only retrieve invalid UTF-8 characters
-   from MongoDB.
+   The current version of the {+driver-short+} automatically substitutes
+   invalid UTF-8 characters with alternate valid UTF-8 ones prior to
+   validation when you send data to MongoDB. Therefore, the validation
+   only throws an error when the setting is enabled and the driver
+   receives invalid UTF-8 document data from MongoDB.
+
+Read the sections below to learn how to set UTF-8 validation using the
+{+driver-short+}.
 
 .. _nodejs-specify-utf-8-validation:
 
@@ -49,7 +51,10 @@ Specify the UTF-8 Validation Setting
 You can specify whether the driver should perform UTF-8 validation by
 defining the ``enableUtf8Validation`` setting in the options parameter
 when you create a client, reference a database or collection, or call a
-CRUD operation. By default, the {+driver-short+} enables UTF-8 validation.
+CRUD operation. If you omit the setting, the driver enables UTF-8 validation.
+
+See the following for code examples that demonstrate how to disable UTF-8
+validation on the client, database, collection, or CRUD operation:
 
 .. code-block:: javascript
 

--- a/source/fundamentals/utf8-validation.txt
+++ b/source/fundamentals/utf8-validation.txt
@@ -1,0 +1,116 @@
+.. _nodejs-utf-8-validation:
+
+================
+UTF-8 Validation
+================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Overview
+--------
+
+In this guide, you can learn how to enable or disable the {+driver-short+}'s
+UTF-8 validation feature. By default, your driver checks documents for any
+characters that are not encoded in a valid UTF-8 format when it transfers data
+between your application and MongoDB.
+
+**UTF-8** is a character encoding specification that is compatible with
+most operating systems, applications, and language character sets. See the
+Wikipedia entry on :wikipedia:`UTF-8 <UTF-8>` for more information on this
+standard.
+
+If you enable validation, the driver substitutes invalid UTF-8 characters
+with valid UTF-8 ones when transferring data between your application and
+MongoDB. The validation adds processing overhead since it needs to verify the
+data and to make substitutions when necessary.
+
+If you disable validation, your application can avoid the processing
+overhead caused by validation, but cannot guarantee consistent presentation of
+invalid UTF-8 data.
+
+.. note::
+
+   The {+driver-short+} automatically substitutes invalid UTF-8 characters
+   in your application before sending them to MongoDB regardless of whether
+   you enable validation. You can only retrieve invalid UTF-8 characters
+   from MongoDB.
+
+.. _nodejs-specify-utf-8-validation:
+
+Specify the UTF-8 Validation Setting
+------------------------------------
+
+You can specify whether the driver should perform UTF-8 validation by
+defining the ``enableUtf8Validation`` setting in the options parameter
+when you create a client, reference a database or collection, or call a
+CRUD operation. By default, the {+driver-short+} enables UTF-8 validation.
+
+.. code-block:: javascript
+
+   // disable UTF-8 validation on the client
+   new MongoClient('<connection uri>', { enableUtf8Validation: false });
+
+   // disable UTF-8 validation on the database
+   client.db('<database name>', { enableUtf8Validation: false });
+
+   // disable UTF-8 validation on the collection
+   db.collection('<collection name>', { enableUtf8Validation: false });
+
+   // disable UTF-8 validation on a specific operation call
+   await collection.findOne({ title: 'Cam Jansen'}, { enableUtf8Validation: false });
+
+If your application reads invalid UTF-8 from MongoDB while the
+``enableUtf8Validation`` option is enabled, it throws a ``BSONError`` that
+contains the following message:
+
+.. code-block::
+
+   Invalid UTF-8 string in BSON document
+
+.. _nodejs-utf-8-validation-scope:
+
+Set the Validation Scope
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``enableUtf8Validation`` setting automatically applies to the scope of the
+object instance on which you included it, and any other objects created by
+calls on that instance.
+
+For example, if you include the option on the call to instantiate a database
+object, any collection instance you construct from that object inherits
+the setting. Any operations you call on that collection instance also
+inherit the setting.
+
+.. code-block:: javascript
+
+   const database = client.db('books', { enableUtf8Validation: false });
+
+   // The collection inherits the UTF-8 validation disabled setting from the database
+   const collection = database.collection('mystery');
+
+   // CRUD operation runs with UTF-8 validation disabled
+   await collection.findOne({ title: 'Encyclopedia Brown' });
+
+You can override the setting at any level of scope by including it when
+constructing the object instance or when calling an operation.
+
+For example, if you disable validation on the collection object, you can
+override the setting in individual CRUD operation calls on that
+collection.
+
+.. code-block:: javascript
+
+   const collection = database.collection('mystery', { enableUtf8Validation: false });
+
+   // CRUD operation runs with UTF-8 validation enabled
+   await collection.findOne({ title: 'Trixie Belden' }, { enableUtf8Validation: true });
+
+   // CRUD operation runs with UTF-8 validation disabled
+   await collection.findOne({ title: 'Enola Holmes' });
+

--- a/source/fundamentals/utf8-validation.txt
+++ b/source/fundamentals/utf8-validation.txt
@@ -29,8 +29,7 @@ overhead, but cannot guarantee consistent presentation of invalid UTF-8 data.
 
 The driver enables UTF-8 validation by default. It checks documents for any
 characters that are not encoded in a valid UTF-8 format when it transfers data
-between your application. If it encounters invalid UTF-8 characters, it
-throws an error.
+between your application and MongoDB.
 
 .. note::
 

--- a/source/fundamentals/utf8-validation.txt
+++ b/source/fundamentals/utf8-validation.txt
@@ -16,14 +16,11 @@ Overview
 --------
 
 In this guide, you can learn how to enable or disable the {+driver-short+}'s
-UTF-8 validation feature. By default, your driver checks documents for any
-characters that are not encoded in a valid UTF-8 format when it transfers data
-between your application and MongoDB.
-
-**UTF-8** is a character encoding specification that is compatible with
-most operating systems, applications, and language character sets. See the
-Wikipedia entry on :wikipedia:`UTF-8 <UTF-8>` for more information on this
-standard.
+**UTF-8** validation feature. **UTF-8** is a character encoding specification
+that ensures compatibility and consistent presentation across most operating
+systems, applications, and language character sets. By default, the driver
+checks documents for any characters that are not encoded in a valid UTF-8
+format when it transfers data between your application and MongoDB.
 
 If you enable validation, the driver substitutes invalid UTF-8 characters
 with valid UTF-8 ones when transferring data between your application and
@@ -33,6 +30,9 @@ data and to make substitutions when necessary.
 If you disable validation, your application can avoid the processing
 overhead caused by validation, but cannot guarantee consistent presentation of
 invalid UTF-8 data.
+
+Read the sections below to learn how to set UTF-8 validation using the
+{+driver-short+}.
 
 .. note::
 

--- a/source/includes/fundamentals-sections.rst
+++ b/source/includes/fundamentals-sections.rst
@@ -11,3 +11,5 @@ Fundamentals section:
 - :doc:`Log Events in the Driver </fundamentals/logging>`
 - :doc:`Monitor Driver Events </fundamentals/monitoring>`
 - :doc:`Store and Retrieve Large Files in MongoDB </fundamentals/gridfs>`
+- :doc:`Use TypeScript Types with the Driver </fundamentals/typescript>`
+- :doc:`Specify UTF-8 Validation Settings </fundamentals/utf8-validation>`

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -26,7 +26,7 @@ What's New in 4.3
 New features of the 4.3 Node.js driver release include:
 
 - SOCKS5 support
-- Option to disable UTF-8 validation
+- Option to :ref:`disable UTF-8 validation <nodejs-utf-8-validation>`
 - Type inference for nested documents
 
 .. _version-4.2:


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-20056

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=61f2c8ddbcf82347e58d0b02

### Docs staging link (requires sign-in on MongoDB Corp SSO):

[What's New link](https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-20056-utf8-option/whats-new/#what-s-new-in-4.3)
[ToC](https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-20056-utf8-option/fundamentals/)
[UTF-8 Validation Page](https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-20056-utf8-option/fundamentals/utf8-validation/)

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [x] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [x] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
