### PR TITLE
Replace instance of versioned with stable

### DIFF
--- a/source/fundamentals/stable-api.txt
+++ b/source/fundamentals/stable-api.txt
@@ -51,8 +51,8 @@ version of the {+stable-api+}.
 
 .. tip::
 
-   If you need to run commands using more than one version of the Versioned
-   API, instantiate a separate client with that version.
+   If you need to run commands using more than one version of the
+   {+stable-api+}, instantiate a separate client with that version.
 
    If you need to run commands not covered by the {+stable-api+}, make sure the
    "strict" option is disabled. See the section on


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
None

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=61f82c9f382d7fe4ee4cdd00

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/013121-fix-versioned-to-stable/fundamentals/stable-api/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
