### PR TITLE
Redirects Fix

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -3,6 +3,6 @@ define: base https://docs.mongodb.com/${prefix}
 define: versions v3.6 v3.7 v4.0 v4.1 v4.2 v4.3 master
 
 raw: ${prefix}/ -> ${base}/current/
-raw: ${prefix}/stable -> ${base}/current/
+raw: ${prefix}/stable/ -> ${base}/current/
 
-[*-master]: ${prefix}/${version}/fundamentals/versioned-api/ -> ${prefix}/${version}/fundamentals/stable-api/
+[*-master]: ${prefix}/${version}/fundamentals/versioned-api/ -> ${base}/${version}/fundamentals/stable-api/


### PR DESCRIPTION
## Pull Request Info

Attempt to fix redirect build error. This seems to correspond [to the error I received](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=61f8648c382d7fe4ee5f7dd8) (redirect must be prefixed with https or http or /).

[Other redirects files](https://github.com/10gen/docs-kafka-connector/blob/master/config/redirects#L8) also seem to link to `${base}` rather than `${prefix}`. 

### Issue JIRA link:

None

### Snooty build log:

[No visible changes](https://docs-mongodborg-staging.corp.mongodb.com/node/docsworker-xlarge/redirects-fix/)

### Docs staging link (requires sign-in on MongoDB Corp SSO):

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=61f88a59382d7fe4ee6a9559

### Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Does it render on staging correctly?
- [ ] Are all the links working?
- [ ] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
