### PR TITLE
add ref to landing page for guides

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -26,8 +26,8 @@ MongoDB Node Driver
 Introduction
 ------------
 
-Welcome to the documentation site for the official MongoDB Node.js
-driver. You can add the driver to your application to work with MongoDB
+Welcome to the documentation site for the official {+driver-long+}.
+You can add the driver to your application to work with MongoDB
 in JavaScript. Download it using `npm <https://www.npmjs.com/>`__
 or set up a runnable project by following our Quick Start guide.
 

--- a/source/index.txt
+++ b/source/index.txt
@@ -2,6 +2,8 @@
 MongoDB Node Driver
 ===================
 
+.. _node-driver-landing:
+
 .. default-domain:: mongodb
 
 .. include:: /includes/unicode-checkmark.rst
@@ -24,9 +26,9 @@ MongoDB Node Driver
 Introduction
 ------------
 
-Welcome to the documentation site for the official MongoDB Node.js 
-driver. You can add the driver to your application to work with MongoDB 
-in JavaScript. Download it using `npm <https://www.npmjs.com/>`__ 
+Welcome to the documentation site for the official MongoDB Node.js
+driver. You can add the driver to your application to work with MongoDB
+in JavaScript. Download it using `npm <https://www.npmjs.com/>`__
 or set up a runnable project by following our Quick Start guide.
 
 


### PR DESCRIPTION
## Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

### Issue JIRA link:
N/A

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6228fd731a622fb27492ad2f

### Docs staging link (requires sign-in on MongoDB Corp SSO):
[Staged](https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/add-ref/)
### Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Does it render on staging correctly?
- [ ] Are all the links working?
- [ ] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
