### PR TITLE
DOCSP-21400: remove shared role references

### DIFF
--- a/source/fundamentals/gridfs.txt
+++ b/source/fundamentals/gridfs.txt
@@ -266,7 +266,7 @@ code example shows you how to delete a GridFS bucket:
 
    bucket.drop();
 
-For more information on this method, see the `drop() <{+api+}/classes/GridFSBucket.html#drop>__
+For more information on this method, see the `drop() <{+api+}/classes/GridFSBucket.html#drop>`__
 API documentation.
 
 Additional Resources

--- a/source/fundamentals/gridfs.txt
+++ b/source/fundamentals/gridfs.txt
@@ -226,8 +226,8 @@ The following example shows how to update the ``filename`` field to
 
    bucket.rename(ObjectId("60edece5e06275bf0463aaf3"), "newFileName");
 
-For more information on this method, see the :node-api-4.0:`rename() API
-documentation <classes/gridfsbucket.html#rename>`.
+For more information on this method, see the `rename() <{+api+}/classes/GridFSBucket.html#rename>`__
+API documentation.
 
 .. _gridfs-delete-files:
 
@@ -250,8 +250,8 @@ The following example shows you how to delete a file by referencing its ``_id`` 
 
    bucket.delete(ObjectId("60edece5e06275bf0463aaf3"));
 
-For more information on this method, see the :node-api-4.0:`delete() API
-documentation <classes/gridfsbucket.html#delete>`.
+For more information on this method, see the `delete() <{+api+}/classes/GridFSBucket.html#delete>`__
+API documentation.
 
 .. _gridfs-delete-bucket:
 
@@ -266,13 +266,11 @@ code example shows you how to delete a GridFS bucket:
 
    bucket.drop();
 
-For more information on this method, see the :node-api-4.0:`drop() API
-documentation </classes/gridfsbucket.html#drop>`.
+For more information on this method, see the `drop() <{+api+}/classes/GridFSBucket.html#drop>__
+API documentation.
 
 Additional Resources
 --------------------
 
 - `MongoDB GridFS specification <https://github.com/mongodb/specifications/blob/master/source/gridfs/gridfs-spec.rst>`__
-- `Runnable example <https://mongodb.github.io/node-mongodb-native/3.6/tutorials/gridfs/streaming/>`__
-  from the Node driver version 3.6 documentation
 


### PR DESCRIPTION
## Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

Applies to all docs versions after 4.0

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-21400

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6230a0820ab54725f1552f95

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-21400-remove-roles/fundamentals/gridfs/

### Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Does it render on staging correctly?
- [ ] Are all the links working?
- [ ] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
