### PR TITLE
DOCSP-22039 link fix

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -3,6 +3,7 @@ title = "Node.js"
 intersphinx = [
     "https://www.mongodb.com/docs/manual/objects.inv",
     "https://www.mongodb.com/docs/drivers/objects.inv",
+    "https://www.mongodb.com/docs/atlas/objects.inv",
 ]
 
 toc_landing_pages = [

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -71,7 +71,7 @@ What's New in 4.1
 New features of the 4.1 Node.js driver release include:
 
 - Added load balanced connection support for all cluster types including
-  the beta :atlas:`Serverless platform </choose-database-deployment-type/?tck=docs_driver_nodejs>`.
+  the beta :ref:`Serverless platform <create-new-database-deployment>`.
 - Added support for the ``advanceClusterTime()`` method to determine if
   the ``ClientSession`` should update its cluster time.
 


### PR DESCRIPTION
## Pull Request Info

Updated the link to the serverless deployment page.

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-NNNNN

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=625888a40fdfea9c3713e601

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-22039-LinkFix/whats-new/#what-s-new-in-4.1

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
