### PR TITLE
DOCSP-21125 pkfactory and upsert operations

### DIFF
--- a/source/fundamentals/crud/write-operations/change-a-document.txt
+++ b/source/fundamentals/crud/write-operations/change-a-document.txt
@@ -122,6 +122,8 @@ an :doc:`upsert </fundamentals/crud/write-operations/upsert>` which
 attempts to perform an update, but if no documents are matched, inserts
 a new document.
 
+.. include:: /includes/pkfactory-upsert.rst
+
 You cannot modify the ``_id`` field of a document nor change a field to
 a value that violates a unique index constraint. See the MongoDB server manual
 for more information on :manual:`unique indexes </core/index-unique/>`.
@@ -197,6 +199,8 @@ does not make any changes. Replace operations can be configured to perform
 an :doc:`upsert </fundamentals/crud/write-operations/upsert>` which
 attempts to perform the replacement, but if no documents are matched, it
 inserts a new document.
+
+.. include:: /includes/pkfactory-upsert.rst
 
 You cannot modify the ``_id`` field of a document nor change a field to
 a value that violates a unique index constraint. See the MongoDB server manual

--- a/source/fundamentals/crud/write-operations/upsert.txt
+++ b/source/fundamentals/crud/write-operations/upsert.txt
@@ -1,3 +1,5 @@
+.. _node-fundamentals-upsert:
+
 ======================================
 Insert or Update in a Single Operation
 ======================================
@@ -76,6 +78,8 @@ update the document, we can set ``upsert`` to ``true`` in our call to
    const options = { upsert: true };
    collection.updateOne(query, update, options);
 
+.. include:: /includes/pkfactory-upsert.rst
+   
 After you run the operation above, your collection should resemble the
 following, whether the "Deli Llama" document existed in your collection
 beforehand:

--- a/source/fundamentals/typescript.txt
+++ b/source/fundamentals/typescript.txt
@@ -190,6 +190,8 @@ documents in your collection but you do not want to specify values for the
 create your collection. The ``OptionalId`` type accepts a type parameter as an
 argument and returns that type with an optional ``_id`` field.
 
+.. include:: /includes/pkfactory-upsert.rst
+
 The following code snippet defines the ``IdPet`` interface, which
 includes a type for the ``_id`` field:
 

--- a/source/includes/pkfactory-upsert.rst
+++ b/source/includes/pkfactory-upsert.rst
@@ -1,0 +1,12 @@
+.. important:: PkFactory in Upsert Operations
+
+    When performing an :ref:`upsert operation
+    <node-fundamentals-upsert>`, the driver doesn't use any
+    ``PkFactory`` methods. Instead, the driver always creates
+    ``ObjectId`` values for the ``_id`` field of the
+    upserted documents.
+
+    If you want to use ``PkFactory`` methods, peform a :ref:`find
+    operation <node-fundamentals-retrieve-data>`, then an :ref:`update
+    <node-fundamentals-change-a-document>` or :ref:`insert
+    <node-fundamentals-insert-data>` operation.

--- a/source/usage-examples/replaceOne.txt
+++ b/source/usage-examples/replaceOne.txt
@@ -28,6 +28,8 @@ You can specify additional options, such as ``upsert``, using the
 optional ``options`` parameter. If you set the ``upsert`` option field to
 ``true`` the method inserts a new document if no document matches the query.
 
+.. include:: /includes/pkfactory-upsert.rst
+   
 The ``replaceOne()`` method throws an exception if an error occurs
 during execution. For example, if you specify a value that violates a
 unique index rule, ``replaceOne()`` throws a ``duplicate key error``.

--- a/source/usage-examples/updateOne.txt
+++ b/source/usage-examples/updateOne.txt
@@ -29,6 +29,8 @@ Set the ``upsert`` option to ``true`` to create a new document
 if no documents match the filter. For additional information, see the
 `updateOne() API documentation <{+api+}/classes/Collection.html#updateOne>`__.
 
+.. include:: /includes/pkfactory-upsert.rst
+   
 ``updateOne()`` throws an exception if an error occurs during execution.
 If you specify a value in your update document for the immutable field
 ``_id``, the method throws an exception. If your update document contains


### PR DESCRIPTION
# Pull Request Info

Added an admonition to inform users to not use pkfactory with upsert operations.

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-21125>
Staging:
- <https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-21125/fundamentals/typescript/#insert-operations-and-the-_id-field>
- <https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-21125/fundamentals/crud/write-operations/upsert/#performing-an-upsert>
- <https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-21125/fundamentals/crud/write-operations/change-a-document/> 
- <https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-21125/usage-examples/updateOne/>
- <https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-21125/usage-examples/replaceOne/>

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
