### PR TITLE
Hide output in io-code-block by default

### DIFF
--- a/source/quick-reference.txt
+++ b/source/quick-reference.txt
@@ -24,6 +24,7 @@ their related reference and API documentation.
 
      - .. io-code-block::
           :copyable: true
+          :visible: false
 
           .. input::
              :language: js
@@ -32,7 +33,7 @@ their related reference and API documentation.
 
           .. output::
              :language: js
-             :visible: false
+             
 
              { title: 'Hamlet', type: 'movie', ... }
 
@@ -44,6 +45,7 @@ their related reference and API documentation.
 
      - .. io-code-block::
           :copyable: true
+          :visible: false
 
           .. input::
              :language: js
@@ -93,6 +95,7 @@ their related reference and API documentation.
 
      - .. io-code-block::
           :copyable: true
+          :visible: false
 
           .. input::
              :language: js
@@ -116,6 +119,7 @@ their related reference and API documentation.
 
      - .. io-code-block::
           :copyable: true
+          :visible: false
 
           .. input::
              :language: js
@@ -142,6 +146,7 @@ their related reference and API documentation.
 
      - .. io-code-block::
           :copyable: true
+          :visible: false
 
           .. input::
              :language: js
@@ -165,6 +170,7 @@ their related reference and API documentation.
 
      - .. io-code-block::
           :copyable: true
+          :visible: false
 
           .. input::
              :language: js
@@ -209,6 +215,7 @@ their related reference and API documentation.
 
      - .. io-code-block::
           :copyable: true
+          :visible: false
 
           .. input::
              :language: js
@@ -258,6 +265,7 @@ their related reference and API documentation.
 
      - .. io-code-block::
           :copyable: true
+          :visible: false
 
           .. input::
              :language: js
@@ -282,6 +290,7 @@ their related reference and API documentation.
 
      - .. io-code-block::
           :copyable: true
+          :visible: false
 
           .. input::
              :language: js
@@ -306,6 +315,7 @@ their related reference and API documentation.
 
      - .. io-code-block::
           :copyable: true
+          :visible: false
 
           .. input::
              :language: js
@@ -325,6 +335,7 @@ their related reference and API documentation.
 
      - .. io-code-block::
           :copyable: true
+          :visible: false
 
           .. input::
              :language: js
@@ -344,6 +355,7 @@ their related reference and API documentation.
 
      - .. io-code-block::
           :copyable: true
+          :visible: false
 
           .. input::
              :language: js
@@ -366,6 +378,7 @@ their related reference and API documentation.
 
      - .. io-code-block::
           :copyable: true
+          :visible: false
 
           .. input::
              :language: js
@@ -389,6 +402,7 @@ their related reference and API documentation.
 
      - .. io-code-block::
           :copyable: true
+          :visible: false
 
           .. input::
              :language: js
@@ -413,6 +427,7 @@ their related reference and API documentation.
 
      - .. io-code-block::
           :copyable: true
+          :visible: false
 
           .. input::
              :language: js
@@ -445,6 +460,7 @@ their related reference and API documentation.
 
      - .. io-code-block::
           :copyable: true
+          :visible: false
 
           .. input::
              :language: js

--- a/source/quick-reference.txt
+++ b/source/quick-reference.txt
@@ -32,6 +32,7 @@ their related reference and API documentation.
 
           .. output::
              :language: js
+             :visible: false
 
              { title: 'Hamlet', type: 'movie', ... }
 
@@ -51,6 +52,7 @@ their related reference and API documentation.
 
           .. output::
              :language: js
+             :visible: false
 
              [
                { title: 'Christmas in Boston', year: 2005, ... },
@@ -102,6 +104,7 @@ their related reference and API documentation.
 
           .. output::
              :language: js
+             :visible: false
 
              { title: 'Amadeus', imdb: { rating: 9.5, ... } }
 
@@ -124,6 +127,7 @@ their related reference and API documentation.
 
           .. output::
              :language: js
+             :visible: false
 
              [
                { title: 'A Beautiful Mind', year: 2001, imdb: { votes: 826257, ... },
@@ -149,6 +153,7 @@ their related reference and API documentation.
 
           .. output::
              :language: js
+             :visible: false
 
              { title: 'Cosmos', genres: [ 'Documentary', 'Educational' ] }
 
@@ -171,6 +176,7 @@ their related reference and API documentation.
 
           .. output::
              :language: js
+             :visible: false
 
              { name: 'Lord of the Wings', zipcode: 10001 }
 
@@ -225,6 +231,7 @@ their related reference and API documentation.
 
           .. output::
              :language: js
+             :visible: false
 
              BulkWriteResult {
                result: {
@@ -260,6 +267,7 @@ their related reference and API documentation.
 
           .. output::
              :language: js
+             :visible: false
 
              [
                { title: '2001: A Space Odyssey', ... },
@@ -283,6 +291,7 @@ their related reference and API documentation.
 
           .. output::
              :language: js
+             :visible: false
 
              [
                { title: '2001: A Space Odyssey', ... },
@@ -305,6 +314,7 @@ their related reference and API documentation.
 
           .. output::
              :language: js
+             :visible: false
 
              618
 
@@ -323,6 +333,7 @@ their related reference and API documentation.
 
           .. output::
              :language: js
+             :visible: false
 
              [ 1891, 1893, 1894, 1896, 1903, ... ]
 
@@ -341,6 +352,7 @@ their related reference and API documentation.
 
           .. output::
              :language: js
+             :visible: false
 
              [
                { title: 'My Neighbor Totoro', ... },
@@ -362,6 +374,7 @@ their related reference and API documentation.
 
           .. output::
              :language: js
+             :visible: false
 
              [
                { title: 'Rocky III', ... },
@@ -384,6 +397,7 @@ their related reference and API documentation.
 
           .. output::
              :language: js
+             :visible: false
 
              [
                { title: 'Newark Athlete', year: 1891, ... },
@@ -440,6 +454,7 @@ their related reference and API documentation.
 
           .. output::
              :language: js
+             :visible: false
 
              [
                { title: 'The Life Aquatic with Steve Zissou', ... }

--- a/source/quick-reference.txt
+++ b/source/quick-reference.txt
@@ -24,7 +24,6 @@ their related reference and API documentation.
 
      - .. io-code-block::
           :copyable: true
-          :visible: false
 
           .. input::
              :language: js
@@ -45,7 +44,6 @@ their related reference and API documentation.
 
      - .. io-code-block::
           :copyable: true
-          :visible: false
 
           .. input::
              :language: js
@@ -95,7 +93,6 @@ their related reference and API documentation.
 
      - .. io-code-block::
           :copyable: true
-          :visible: false
 
           .. input::
              :language: js
@@ -119,7 +116,6 @@ their related reference and API documentation.
 
      - .. io-code-block::
           :copyable: true
-          :visible: false
 
           .. input::
              :language: js
@@ -146,7 +142,6 @@ their related reference and API documentation.
 
      - .. io-code-block::
           :copyable: true
-          :visible: false
 
           .. input::
              :language: js
@@ -170,7 +165,6 @@ their related reference and API documentation.
 
      - .. io-code-block::
           :copyable: true
-          :visible: false
 
           .. input::
              :language: js
@@ -215,7 +209,6 @@ their related reference and API documentation.
 
      - .. io-code-block::
           :copyable: true
-          :visible: false
 
           .. input::
              :language: js
@@ -265,7 +258,6 @@ their related reference and API documentation.
 
      - .. io-code-block::
           :copyable: true
-          :visible: false
 
           .. input::
              :language: js
@@ -290,7 +282,6 @@ their related reference and API documentation.
 
      - .. io-code-block::
           :copyable: true
-          :visible: false
 
           .. input::
              :language: js
@@ -315,7 +306,6 @@ their related reference and API documentation.
 
      - .. io-code-block::
           :copyable: true
-          :visible: false
 
           .. input::
              :language: js
@@ -335,7 +325,6 @@ their related reference and API documentation.
 
      - .. io-code-block::
           :copyable: true
-          :visible: false
 
           .. input::
              :language: js
@@ -355,7 +344,6 @@ their related reference and API documentation.
 
      - .. io-code-block::
           :copyable: true
-          :visible: false
 
           .. input::
              :language: js
@@ -378,7 +366,6 @@ their related reference and API documentation.
 
      - .. io-code-block::
           :copyable: true
-          :visible: false
 
           .. input::
              :language: js
@@ -402,7 +389,6 @@ their related reference and API documentation.
 
      - .. io-code-block::
           :copyable: true
-          :visible: false
 
           .. input::
              :language: js
@@ -427,7 +413,6 @@ their related reference and API documentation.
 
      - .. io-code-block::
           :copyable: true
-          :visible: false
 
           .. input::
              :language: js
@@ -460,7 +445,6 @@ their related reference and API documentation.
 
      - .. io-code-block::
           :copyable: true
-          :visible: false
 
           .. input::
              :language: js

--- a/source/quick-reference.txt
+++ b/source/quick-reference.txt
@@ -32,7 +32,7 @@ their related reference and API documentation.
 
           .. output::
              :language: js
-             
+             :visible: false          
 
              { title: 'Hamlet', type: 'movie', ... }
 

--- a/source/quick-reference.txt
+++ b/source/quick-reference.txt
@@ -421,6 +421,7 @@ their related reference and API documentation.
 
           .. output::
              :language: js
+             :visible: false
 
              [
                { year: 2012, imdb: { rating: 5.8, votes: 230, id: 8256 }},


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - None
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/050222-default-visible-output/quick-reference/

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Are all the links working?
