### PR TITLE
DOCSP-22799 updated example

### DIFF
--- a/source/code-snippets/monitoring/apm-subscribe.js
+++ b/source/code-snippets/monitoring/apm-subscribe.js
@@ -5,7 +5,7 @@ const { MongoClient } = require("mongodb");
 const uri =
   "mongodb+srv://<clusterUrl>/?replicaSet=rs&writeConcern=majority";
 
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, { monitorCommands:true });
 
 // Replace <event name> with the name of the event you are subscribing to.
 const eventName = "<event name>";

--- a/source/fundamentals/monitoring/command-monitoring.txt
+++ b/source/fundamentals/monitoring/command-monitoring.txt
@@ -32,8 +32,9 @@ events created by the MongoDB deployment:
 
 .. note::
 
-   To trigger events, enable command monitoring for the ``client`` by
-   specifying the ``monitorCommands`` option to ``true``.
+   Command monitoring is disabled by default. To enable command
+   monitoring, pass the ``monitorCommands`` option as ``true`` to
+   your ``MongoClient`` constructor. 
 
 Event Descriptions
 ------------------

--- a/source/fundamentals/monitoring/command-monitoring.txt
+++ b/source/fundamentals/monitoring/command-monitoring.txt
@@ -30,6 +30,11 @@ events created by the MongoDB deployment:
 .. literalinclude:: /code-snippets/monitoring/apm-subscribe.js
    :language: javascript
 
+.. note::
+
+   To trigger events, enable command monitoring for the ``client`` by
+   specifying the ``monitorCommands`` option to ``true``.
+
 Event Descriptions
 ------------------
 


### PR DESCRIPTION
# Pull Request Info

Updated the example on the Cluster Monitoring page to include the monitorCommands option and a note calling out you must specify the option to enable monitoring.

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-22799>
Staging - <https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-22799/fundamentals/monitoring/command-monitoring/#event-subscription-example>

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
