### PR TITLE
070722 revert quickstart line

### DIFF
--- a/source/quick-start.txt
+++ b/source/quick-start.txt
@@ -180,6 +180,8 @@ application.
 
         async function run() {
           try {
+            await client.connect();
+
             const database = client.db('sample_mflix');
             const movies = database.collection('movies');
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

Fixes mistake in quick-start code introduced in recent updates. Adds the "await client.connect()" line back. Applies to v4.6 and earlier.

JIRA - None
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/070722-revert-quickstart-line/quick-start/

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
