### PR TITLE
DOCSP-22548: remove client.connect() from examples

### DIFF
--- a/source/code-snippets/aggregation/agg.js
+++ b/source/code-snippets/aggregation/agg.js
@@ -3,8 +3,6 @@ const uri = process.env.MONGDODB_URI;
 const client = new MongoClient(uri);
 
 async function run() {
-    await client.connect();
-
     // begin data insertion
     const db = client.db("aggregation");
     const coll = db.collection("restaurants");

--- a/source/code-snippets/authentication/aws-env-variable.js
+++ b/source/code-snippets/authentication/aws-env-variable.js
@@ -13,9 +13,6 @@ const client = new MongoClient(uri);
 
 async function run() {
   try {
-    // Connect the client to the server.
-    await client.connect();
-
     // Establish and verify connection.
     await client.db("admin").command({ ping: 1 });
     console.log("Connected successfully to server.");

--- a/source/code-snippets/authentication/aws.js
+++ b/source/code-snippets/authentication/aws.js
@@ -19,9 +19,6 @@ const client = new MongoClient(uri);
 
 async function run() {
   try {
-    // Connect the client to the server.
-    await client.connect();
-
     // Establish and verify connection.
     await client.db("admin").command({ ping: 1 });
     console.log("Connected successfully to server.");

--- a/source/code-snippets/authentication/cr.js
+++ b/source/code-snippets/authentication/cr.js
@@ -15,9 +15,6 @@ const client = new MongoClient(uri);
 // Function to connect to the server
 async function run() {
   try {
-    // Connect the client to the server
-    await client.connect();
-
     // Establish and verify connection
     await client.db("admin").command({ ping: 1 });
     console.log("Connected successfully to server");

--- a/source/code-snippets/authentication/default.js
+++ b/source/code-snippets/authentication/default.js
@@ -17,9 +17,6 @@ const client = new MongoClient(uri);
 // Function to connect to the server
 async function run() {
   try {
-    // Connect the client to the server
-    await client.connect();
-
     // Establish and verify connection
     await client.db("admin").command({ ping: 1 });
     console.log("Connected successfully to server");

--- a/source/code-snippets/authentication/sha1.js
+++ b/source/code-snippets/authentication/sha1.js
@@ -17,9 +17,6 @@ const client = new MongoClient(uri);
 // Function to connect to the server
 async function run() {
   try {
-    // Connect the client to the server
-    await client.connect();
-
     // Establish and verify connection
     await client.db("admin").command({ ping: 1 });
     console.log("Connected successfully to server");

--- a/source/code-snippets/authentication/sha256.js
+++ b/source/code-snippets/authentication/sha256.js
@@ -17,9 +17,6 @@ const client = new MongoClient(uri);
 // Function to connect to the server
 async function run() {
   try {
-    // Connect the client to the server
-    await client.connect();
-
     // Establish and verify connection
     await client.db("admin").command({ ping: 1 });
     console.log("Connected successfully to server");

--- a/source/code-snippets/authentication/x509.js
+++ b/source/code-snippets/authentication/x509.js
@@ -17,9 +17,6 @@ const client = new MongoClient(uri);
 // Function to connect to the server
 async function run() {
   try {
-    // Connect the client to the server
-    await client.connect();
-
     // Establish and verify connection
     await client.db("admin").command({ ping: 1 });
     console.log("Connected successfully to server");

--- a/source/code-snippets/connection/srv.js
+++ b/source/code-snippets/connection/srv.js
@@ -9,7 +9,7 @@ const client = new MongoClient(uri);
 
 async function run() {
   try {
-    // Connect the client to the server
+    // Connect the client to the server (optional starting in v4.7)
     await client.connect();
 
     // Establish and verify connection

--- a/source/code-snippets/crud/arrayFilters.js
+++ b/source/code-snippets/crud/arrayFilters.js
@@ -9,8 +9,6 @@ const client = new MongoClient(uri);
 
 async function loadData() {
   try {
-    await client.connect();
-
     const database = client.db("test");
     const pizza = database.collection("pizza");
 
@@ -76,8 +74,6 @@ async function loadData() {
 async function runAllArrayElements() {
 
   try {
-    await client.connect();
-
     const database = client.db("test");
     const pizza = database.collection("pizza");
 
@@ -99,8 +95,6 @@ async function runAllArrayElements() {
 async function runFirstArrayElement() {
 
   try {
-    await client.connect();
-
     const database = client.db("test");
     const pizza = database.collection("pizza");
 
@@ -123,8 +117,6 @@ async function runFirstArrayElement() {
 
 async function arrayFiltersOne() {
   try {
-    await client.connect();
-
     const database = client.db("test");
     const pizza = database.collection("pizza");
 
@@ -154,8 +146,6 @@ async function arrayFiltersOne() {
 
 async function arrayFiltersTwo() {
   try {
-    await client.connect();
-
     const database = client.db("test");
     const pizza = database.collection("pizza");
 

--- a/source/code-snippets/crud/cursor.js
+++ b/source/code-snippets/crud/cursor.js
@@ -82,8 +82,6 @@ async function count(collection) {
 
 async function run() {
   try {
-    await client.connect();
-
     const database = client.db("test");
     const orders = database.collection("orders");
 

--- a/source/code-snippets/crud/pizza.js
+++ b/source/code-snippets/crud/pizza.js
@@ -11,8 +11,6 @@ function sleep(ms) {
 
 async function run() {
   try {
-    await client.connect();
-
     const database = client.db("test");
     const orders = database.collection("orders");
 

--- a/source/code-snippets/crud/startrek.js
+++ b/source/code-snippets/crud/startrek.js
@@ -97,8 +97,6 @@ async function relevance(movies) {
 
 async function run() {
   try {
-    await client.connect();
-
     const database = client.db("sample_mflix");
     const movies = database.collection("movies");
 

--- a/source/code-snippets/crud/theaters.js
+++ b/source/code-snippets/crud/theaters.js
@@ -60,8 +60,6 @@ async function range(theaters) {
 
 async function run() {
   try {
-    await client.connect();
-
     const database = client.db("sample_mflix");
     const theaters = database.collection("theaters");
 

--- a/source/code-snippets/indexes/compound.js
+++ b/source/code-snippets/indexes/compound.js
@@ -9,8 +9,6 @@ const client = new MongoClient(uri);
 
 async function run() {
   try {
-    await client.connect();
-
     // begin-idx
     const database = client.db("sample_mflix");
     const movies = database.collection("movies");

--- a/source/code-snippets/indexes/geo.js
+++ b/source/code-snippets/indexes/geo.js
@@ -9,8 +9,6 @@ const client = new MongoClient(uri);
 
 async function run() {
   try {
-    await client.connect();
-
     // begin-idx
     const database = client.db("sample_mflix");
     const movies = database.collection("movies");

--- a/source/code-snippets/indexes/multikey.js
+++ b/source/code-snippets/indexes/multikey.js
@@ -9,8 +9,6 @@ const client = new MongoClient(uri);
 
 async function run() {
   try {
-    await client.connect();
-
     // begin-idx
     const database = client.db("sample_mflix");
     const movies = database.collection("movies");

--- a/source/code-snippets/indexes/single-field.js
+++ b/source/code-snippets/indexes/single-field.js
@@ -9,8 +9,6 @@ const client = new MongoClient(uri);
 
 async function run() {
   try {
-    await client.connect();
-
     // begin-idx
     const database = client.db("sample_mflix");
     const movies = database.collection("movies");

--- a/source/code-snippets/indexes/text.js
+++ b/source/code-snippets/indexes/text.js
@@ -9,8 +9,6 @@ const client = new MongoClient(uri);
 
 async function run() {
   try {
-    await client.connect();
-
     // begin-idx
     const database = client.db("sample_mflix");
     const movies = database.collection("movies");

--- a/source/code-snippets/indexes/unique.js
+++ b/source/code-snippets/indexes/unique.js
@@ -9,8 +9,6 @@ const client = new MongoClient(uri);
 
 async function run() {
   try {
-    await client.connect();
-
     // begin-idx
     const database = client.db("sample_mflix");
     const movies = database.collection("movies");

--- a/source/code-snippets/monitoring/apm-subscribe.js
+++ b/source/code-snippets/monitoring/apm-subscribe.js
@@ -15,8 +15,6 @@ client.on(eventName, event => {
 
 async function run() {
   try {
-    await client.connect();
-
     // Establish and verify connection
     await client.db("admin").command({ ping: 1 });
     console.log("Connected successfully");

--- a/source/code-snippets/monitoring/sdam-subscribe.js
+++ b/source/code-snippets/monitoring/sdam-subscribe.js
@@ -15,8 +15,6 @@ client.on(eventName, event => {
 
 async function run() {
   try {
-    await client.connect();
-
     // Establish and verify connection
     await client.db("admin").command({ ping: 1 });
     console.log("Connected successfully");

--- a/source/code-snippets/quick-reference.js
+++ b/source/code-snippets/quick-reference.js
@@ -154,8 +154,6 @@ async function distinct(coll) {
 
 async function run() {
   try {
-    await client.connect();
-
     const database = client.db("sample_mflix");
     const collection = database.collection("movies");
 

--- a/source/code-snippets/transactions/txn-callback.js
+++ b/source/code-snippets/transactions/txn-callback.js
@@ -35,7 +35,6 @@ async function queryData() {
   const uri = process.env.MONGODB_URI;
   const client = new MongoClient(uri, { useUnifiedTopology: true });
   try {
-    await client.connect();
     await Promise.all(['customers', 'inventory', 'orders'].map(async c => {
       const coll = client.db('testdb').collection(c);
       console.log(JSON.stringify(await coll.find().toArray()));
@@ -96,7 +95,6 @@ const client = new MongoClient(uri, { useUnifiedTopology: true });
 
 async function run() {
   /* Test code: uncomment block to run
-  await client.connect();
   await cleanUp(client);
   await setup(client);
 

--- a/source/code-snippets/transactions/txn-core.js
+++ b/source/code-snippets/transactions/txn-core.js
@@ -30,7 +30,6 @@ async function queryData() {
   const uri = process.env.MONGODB_URI;
   const client = new MongoClient(uri, { useUnifiedTopology: true });
   try {
-    await client.connect();
     await Promise.all(['customers', 'inventory', 'orders'].map(async c => {
       const coll = client.db('testdb').collection(c);
       console.log(JSON.stringify(await coll.find().toArray()));
@@ -115,7 +114,6 @@ async function run() {
   const uri = process.env.MONGODB_URI;
   const client = new MongoClient(uri, { useNewUrlParser: true, useUnifiedTopology: true });
 
-  await client.connect();
   await cleanUp(client);
   await setup(client);
 

--- a/source/code-snippets/usage-examples/bulkWrite.js
+++ b/source/code-snippets/usage-examples/bulkWrite.js
@@ -7,8 +7,6 @@ const client = new MongoClient(uri);
 
 async function run() {
   try {
-    await client.connect();
-
     const database = client.db("sample_mflix");
     const theaters = database.collection("theaters");
 

--- a/source/code-snippets/usage-examples/bulkWrite.ts
+++ b/source/code-snippets/usage-examples/bulkWrite.ts
@@ -19,8 +19,6 @@ interface Theater {
 
 async function run() {
   try {
-    await client.connect();
-
     const database = client.db("sample_mflix");
     const theaters = database.collection<Theater>("theaters");
 

--- a/source/code-snippets/usage-examples/changeStream.js
+++ b/source/code-snippets/usage-examples/changeStream.js
@@ -13,7 +13,6 @@ const simulateAsyncPause = () =>
 let changeStream;
 async function run() {
   try {
-    await client.connect();
     const database = client.db("insertDB");
     const collection = database.collection("haikus");
 

--- a/source/code-snippets/usage-examples/command.js
+++ b/source/code-snippets/usage-examples/command.js
@@ -7,8 +7,6 @@ const client = new MongoClient(uri);
 
 async function run() {
   try {
-    await client.connect();
-
     const db = client.db("sample_mflix");
     // find the storage statistics for the "sample_mflix" database using the 'dbStats' command
     const result = await db.command({

--- a/source/code-snippets/usage-examples/count.js
+++ b/source/code-snippets/usage-examples/count.js
@@ -7,8 +7,6 @@ const client = new MongoClient(uri);
 
 async function run() {
   try {
-    await client.connect();
-
     const database = client.db("sample_mflix");
     const movies = database.collection("movies");
 

--- a/source/code-snippets/usage-examples/deleteMany.js
+++ b/source/code-snippets/usage-examples/deleteMany.js
@@ -7,8 +7,6 @@ const client = new MongoClient(uri);
 
 async function run() {
   try {
-    await client.connect();
-
     const database = client.db("sample_mflix");
     const movies = database.collection("movies");
     // Query for all movies with a title containing the string "Santa"

--- a/source/code-snippets/usage-examples/deleteMany.ts
+++ b/source/code-snippets/usage-examples/deleteMany.ts
@@ -11,8 +11,6 @@ interface Movie {
 
 async function run() {
   try {
-    await client.connect();
-
     const database = client.db("sample_mflix");
     const movies = database.collection<Movie>("movies");
     const result = await movies.deleteMany({ title: { $regex: "Santa" } });

--- a/source/code-snippets/usage-examples/deleteOne.js
+++ b/source/code-snippets/usage-examples/deleteOne.js
@@ -7,8 +7,6 @@ const client = new MongoClient(uri);
 
 async function run() {
   try {
-    await client.connect();
-
     const database = client.db("sample_mflix");
     const movies = database.collection("movies");
 

--- a/source/code-snippets/usage-examples/distinct.js
+++ b/source/code-snippets/usage-examples/distinct.js
@@ -7,8 +7,6 @@ const client = new MongoClient(uri);
 
 async function run() {
   try {
-    await client.connect();
-
     // define a database and collection on which to run the method
     const database = client.db("sample_mflix");
     const movies = database.collection("movies");

--- a/source/code-snippets/usage-examples/distinct.ts
+++ b/source/code-snippets/usage-examples/distinct.ts
@@ -12,8 +12,6 @@ interface Movie {
 
 async function run() {
   try {
-    await client.connect();
-
     // define a database and collection on which to run the method
     const database = client.db("sample_mflix");
     const movies = database.collection<Movie>("movies");

--- a/source/code-snippets/usage-examples/find.js
+++ b/source/code-snippets/usage-examples/find.js
@@ -7,8 +7,6 @@ const client = new MongoClient(uri);
 
 async function run() {
   try {
-    await client.connect();
-
     const database = client.db("sample_mflix");
     const movies = database.collection("movies");
 

--- a/source/code-snippets/usage-examples/find.ts
+++ b/source/code-snippets/usage-examples/find.ts
@@ -21,8 +21,6 @@ interface Movie {
 
 async function run() {
   try {
-    await client.connect();
-
     const database = client.db("sample_mflix");
     const movies = database.collection<Movie>("movies");
 

--- a/source/code-snippets/usage-examples/findOne.js
+++ b/source/code-snippets/usage-examples/findOne.js
@@ -7,8 +7,6 @@ const client = new MongoClient(uri);
 
 async function run() {
   try {
-    await client.connect();
-
     const database = client.db("sample_mflix");
     const movies = database.collection("movies");
 

--- a/source/code-snippets/usage-examples/findOne.ts
+++ b/source/code-snippets/usage-examples/findOne.ts
@@ -24,8 +24,6 @@ type MovieSummary = Pick<Movie, "title" | "imdb">;
 
 async function run(): Promise<void> {
   try {
-    await client.connect();
-
     const database = client.db("sample_mflix");
     // Specifying a Schema is always optional, but it enables type hinting on
     // finds and inserts

--- a/source/code-snippets/usage-examples/insertMany.js
+++ b/source/code-snippets/usage-examples/insertMany.js
@@ -7,8 +7,6 @@ const client = new MongoClient(uri);
 
 async function run() {
   try {
-    await client.connect();
-
     const database = client.db("insertDB");
     const foods = database.collection("foods");
 

--- a/source/code-snippets/usage-examples/insertMany.ts
+++ b/source/code-snippets/usage-examples/insertMany.ts
@@ -12,8 +12,6 @@ interface Food {
 
 async function run() {
   try {
-    await client.connect();
-
     const database = client.db("insertDB");
     // Specifying a schema is optional, but it enables type hints on
     // finds and inserts

--- a/source/code-snippets/usage-examples/insertOne.js
+++ b/source/code-snippets/usage-examples/insertOne.js
@@ -7,8 +7,6 @@ const client = new MongoClient(uri);
 
 async function run() {
   try {
-    await client.connect();
-
     const database = client.db("insertDB");
     const haiku = database.collection("haiku");
     // create a document to insert

--- a/source/code-snippets/usage-examples/insertOne.ts
+++ b/source/code-snippets/usage-examples/insertOne.ts
@@ -12,8 +12,6 @@ interface Haiku {
 
 async function run() {
   try {
-    await client.connect();
-
     const database = client.db("insertDB");
     // Specifying a Schema is optional, but it enables type hints on
     // finds and inserts

--- a/source/code-snippets/usage-examples/replaceOne.js
+++ b/source/code-snippets/usage-examples/replaceOne.js
@@ -7,8 +7,6 @@ const client = new MongoClient(uri);
 
 async function run() {
   try {
-    await client.connect();
-
     const database = client.db("sample_mflix");
     const movies = database.collection("movies");
 

--- a/source/code-snippets/usage-examples/replaceOne.ts
+++ b/source/code-snippets/usage-examples/replaceOne.ts
@@ -11,8 +11,6 @@ interface Movie {
 
 async function run() {
   try {
-    await client.connect();
-
     const database = client.db("sample_mflix");
     const movies = database.collection<Movie>("movies");
 

--- a/source/code-snippets/usage-examples/updateMany.js
+++ b/source/code-snippets/usage-examples/updateMany.js
@@ -7,8 +7,6 @@ const client = new MongoClient(uri);
 
 async function run() {
   try {
-    await client.connect();
-
     const database = client.db("sample_mflix");
     const movies = database.collection("movies");
 

--- a/source/code-snippets/usage-examples/updateMany.ts
+++ b/source/code-snippets/usage-examples/updateMany.ts
@@ -20,8 +20,6 @@ interface Movie {
 
 async function run() {
   try {
-    await client.connect();
-
     const database = client.db("sample_mflix");
     const movies = database.collection<Movie>("movies");
     const result = await movies.updateMany(

--- a/source/code-snippets/usage-examples/updateOne.js
+++ b/source/code-snippets/usage-examples/updateOne.js
@@ -7,8 +7,6 @@ const client = new MongoClient(uri);
 
 async function run() {
   try {
-    await client.connect();
-
     const database = client.db("sample_mflix");
     const movies = database.collection("movies");
 

--- a/source/code-snippets/usage-examples/updateOne.ts
+++ b/source/code-snippets/usage-examples/updateOne.ts
@@ -12,8 +12,6 @@ interface Movie {
 
 async function run() {
   try {
-    await client.connect();
-
     const database = client.db("sample_mflix");
     const movies = database.collection<Movie>("movies");
 

--- a/source/fundamentals/authentication/enterprise-mechanisms.txt
+++ b/source/fundamentals/authentication/enterprise-mechanisms.txt
@@ -70,9 +70,6 @@ The following code sample authenticates to Kerberos for UNIX using ``GSSAPI``.
    // Function to connect to the server
    async function run() {
      try {
-       // Connect the client to the server
-       await client.connect();
-
        // Establish and verify connection
        await client.db("admin").command({ ping: 1 });
        console.log("Connected successfully to server");
@@ -118,9 +115,6 @@ in the following sample code.
    // Function to connect to the server
    async function run() {
      try {
-       // Connect the client to the server
-       await client.connect();
-
        // Establish and verify connection
        await client.db("admin").command({ ping: 1 });
        console.log("Connected successfully to server");


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

Applies to v4.7 and later

Omitted FAQ, CSFLE, and Fundamentals > Connection snippets.

Note: error and warning in the log is present in current master branch and is unrelated to this PR.


JIRA - <https://jira.mongodb.org/browse/DOCSP-22548>
Staging - Sample: [Usage Example findOne](https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-22548/usage-examples/findOne/)
[Autobuilder Log](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=62c74fe6f7f8bf6d9fac4ad8)


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
