### PR TITLE
docs: fix zstd/zlib references in docs

### DIFF
--- a/source/fundamentals/connection/network-compression.txt
+++ b/source/fundamentals/connection/network-compression.txt
@@ -20,7 +20,7 @@ first one in the list supported by your MongoDB instance.
 
 .. note::
 
-   When using the Snappy or Zlib compression algorithm, you must
+   When using the Snappy or Zstandard compression algorithm, you must
    :ref:`add explicit dependencies <compression-dependencies>`.
 
 .. _enable-compression:
@@ -89,7 +89,7 @@ following code:
 
    npm install --save snappy
 
-To add the Zlib compression algorithm to your application, run the
+To add the Zstandard compression algorithm to your application, run the
 following code: 
 
 .. code-block:: javascript


### PR DESCRIPTION
# Pull Request Info

Fixes a few references to zlib where it should be zstd.

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
