### PR TITLE
DOCSP-23699: fixed format of a heading

### DIFF
--- a/source/fundamentals/crud/read-operations/distinct.txt
+++ b/source/fundamentals/crud/read-operations/distinct.txt
@@ -42,8 +42,8 @@ usage of ``distinct()``:
 Distinct
 --------
 
-The ``distinct()`` method requires one document field parameter. You can specify two optional 
-parameters to adjust the method output:
+The ``distinct()`` method requires a document field as a parameter. You can specify the 
+following optional parameters to adjust the method output:
 
 - A ``query`` parameter to refine your results 
 - An ``options`` parameter to set collation rules
@@ -51,15 +51,14 @@ parameters to adjust the method output:
 Document Field Parameter
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use a document field name as a parameter for the ``distinct()`` method to return a 
-list of the field's unique values.
+Pass the name of the document field to return a list of the field's unique values.
 
 Example
 ```````
 
 The "``Queens``" and "``Manhattan``" borough values each appear more than
 once in the sample documents. However, the following example retrieves the 
-unique values of the ``borough`` field: 
+unique values of the ``borough`` field:
 
 .. code-block:: javascript
 

--- a/source/fundamentals/crud/read-operations/distinct.txt
+++ b/source/fundamentals/crud/read-operations/distinct.txt
@@ -42,12 +42,17 @@ usage of ``distinct()``:
 Distinct
 --------
 
-Use a document field name as a parameter for the ``distinct()`` method to return a 
-list of the field's unique values. You can specify two optional parameters to adjust
-the method output:
+The ``distinct()`` method requires one document field parameter. You can specify two optional
+ parameters to adjust the method output:
 
 - A ``query`` parameter to refine your results 
 - An ``options`` parameter to set collation rules
+
+Document Field Parameter
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use a document field name as a parameter for the ``distinct()`` method to return a 
+list of the field's unique values.
 
 Example
 ```````

--- a/source/fundamentals/crud/read-operations/distinct.txt
+++ b/source/fundamentals/crud/read-operations/distinct.txt
@@ -42,8 +42,8 @@ usage of ``distinct()``:
 Distinct
 --------
 
-The ``distinct()`` method requires one document field parameter. You can specify two optional
- parameters to adjust the method output:
+The ``distinct()`` method requires one document field parameter. You can specify two optional 
+parameters to adjust the method output:
 
 - A ``query`` parameter to refine your results 
 - An ``options`` parameter to set collation rules

--- a/source/usage-examples/distinct.txt
+++ b/source/usage-examples/distinct.txt
@@ -48,7 +48,7 @@ message that resembles the following:
 
    "key" had the wrong type. Expected string, found <non-string type>
 
-Visit :ref:`node-fundamentals-distinct` for more information about the `distinct()` 
+Visit :ref:`node-fundamentals-distinct` for more information about the ``distinct()``
 method. 
 
 Example


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-23699>
Staging - <https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-23699-fix-heading-format/>

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
