### PR TITLE
fix typo on encrypt fields page

### DIFF
--- a/source/fundamentals/encrypt-fields.txt
+++ b/source/fundamentals/encrypt-fields.txt
@@ -66,5 +66,5 @@ The MongoDB manual contains detailed information on the following {+csfle-short+
 - To get started, see the :v6.0:`{+csfle-short+} Quick Start </core/csfle/quick-start>`.
 - To learn how to use {+csfle-short+}, see the :v6.0:`{+csfle-short+} Fundamentals </core/csfle/fundamentals>`.
 - To learn how to integrate your {+csfle-short+} implementation with a KMS, see the :v6.0:`{+csfle-short+} Tutorials </core/csfle/tutorials>`.
-- To learn :{+csfle-short+} concepts, see the :v6.0:`{+csfle-short+} Reference </core/csfle/reference>`.
+- To learn {+csfle-short+} concepts, see the :v6.0:`{+csfle-short+} Reference </core/csfle/reference>`.
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - None
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/080222-typo-fix/fundamentals/encrypt-fields/#client-side-field-level-encryption--csfle-

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
