### PR TITLE
DOCSP-24285 Updating QE/CSFLE links to refs

### DIFF
--- a/source/fundamentals/encrypt-fields.txt
+++ b/source/fundamentals/encrypt-fields.txt
@@ -45,10 +45,10 @@ uniquely.
 
 The MongoDB manual contains detailed information on the following {+qe+} topics:
 
-- To get started, see the :manual:`{+qe+} Quick Start </core/queryable-encryption/quick-start>`.
-- To learn how to use {+qe+}, see the :manual:`{+qe+} Fundamentals </core/queryable-encryption/fundamentals>`.
-- To learn how to integrate your implementation with a KMS, see the {+qe+} :manual:`{+qe+} Tutorials </core/queryable-encryption/tutorials>`.
-- To learn {+qe+} concepts, see the :manual:`{+qe+} Reference </core/queryable-encryption/reference>`.
+- To get started, see the :ref:`{+qe+} Quick Start <qe-quick-start>`.
+- To learn how to use {+qe+}, see the :ref:`{+qe+} Fundamentals <qe-fundamentals>`.
+- To learn how to integrate your implementation with a KMS, see the {+qe+} :ref:`{+qe+} Tutorials <qe-tutorials>`.
+- To learn {+qe+} concepts, see the :ref:`{+qe+} Reference <qe-reference>`.
 
 {+csfle-long+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -63,8 +63,8 @@ is susceptible to recovery using :wikipedia:`frequency analysis <Frequency_analy
 
 The MongoDB manual contains detailed information on the following {+csfle-short+} topics:
 
-- To get started, see the :manual:`{+csfle-short+} Quick Start </core/csfle/quick-start>`.
-- To learn how to use {+csfle-short+}, see the :manual:`{+csfle-short+} Fundamentals </core/csfle/fundamentals>`.
-- To learn how to integrate your {+csfle-short+} implementation with a KMS, see the :manual:`{+csfle-short+} Tutorials </core/csfle/tutorials>`.
-- To learn :{+csfle-short+} concepts, see the :manual:`{+csfle-short+} Reference </core/csfle/reference>`.
+- To get started, see the :ref:`{+csfle-short+} Quick Start <csfle-quick-start>`.
+- To learn how to use {+csfle-short+}, see the :ref:`{+csfle-short+} Fundamentals <csfle-fundamentals>`.
+- To learn how to integrate your {+csfle-short+} implementation with a KMS, see the :ref:`{+csfle-short+} Tutorials <csfle-tutorials>`.
+- To learn :{+csfle-short+} concepts, see the :ref:`{+csfle-short+} Reference <csfle-reference>`.
 

--- a/source/fundamentals/encrypt-fields.txt
+++ b/source/fundamentals/encrypt-fields.txt
@@ -45,10 +45,10 @@ uniquely.
 
 The MongoDB manual contains detailed information on the following {+qe+} topics:
 
-- To get started, see the :v6.0:`{+qe+} Quick Start </core/queryable-encryption/quick-start>`.
-- To learn how to use {+qe+}, see the :v6.0:`{+qe+} Fundamentals </core/queryable-encryption/fundamentals>`.
-- To learn how to integrate your implementation with a KMS, see the {+qe+} :v6.0:`{+qe+} Tutorials </core/queryable-encryption/tutorials>`.
-- To learn {+qe+} concepts, see the :v6.0:`{+qe+} Reference </core/queryable-encryption/reference>`.
+- To get started, see the :manual:`{+qe+} Quick Start </core/queryable-encryption/quick-start>`.
+- To learn how to use {+qe+}, see the :manual:`{+qe+} Fundamentals </core/queryable-encryption/fundamentals>`.
+- To learn how to integrate your implementation with a KMS, see the {+qe+} :manual:`{+qe+} Tutorials </core/queryable-encryption/tutorials>`.
+- To learn {+qe+} concepts, see the :manual:`{+qe+} Reference </core/queryable-encryption/reference>`.
 
 {+csfle-long+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -63,8 +63,8 @@ is susceptible to recovery using :wikipedia:`frequency analysis <Frequency_analy
 
 The MongoDB manual contains detailed information on the following {+csfle-short+} topics:
 
-- To get started, see the :v6.0:`{+csfle-short+} Quick Start </core/csfle/quick-start>`.
-- To learn how to use {+csfle-short+}, see the :v6.0:`{+csfle-short+} Fundamentals </core/csfle/fundamentals>`.
-- To learn how to integrate your {+csfle-short+} implementation with a KMS, see the :v6.0:`{+csfle-short+} Tutorials </core/csfle/tutorials>`.
-- To learn :{+csfle-short+} concepts, see the :v6.0:`{+csfle-short+} Reference </core/csfle/reference>`.
+- To get started, see the :manual:`{+csfle-short+} Quick Start </core/csfle/quick-start>`.
+- To learn how to use {+csfle-short+}, see the :manual:`{+csfle-short+} Fundamentals </core/csfle/fundamentals>`.
+- To learn how to integrate your {+csfle-short+} implementation with a KMS, see the :manual:`{+csfle-short+} Tutorials </core/csfle/tutorials>`.
+- To learn :{+csfle-short+} concepts, see the :manual:`{+csfle-short+} Reference </core/csfle/reference>`.
 

--- a/source/fundamentals/encrypt-fields.txt
+++ b/source/fundamentals/encrypt-fields.txt
@@ -47,7 +47,7 @@ The MongoDB manual contains detailed information on the following {+qe+} topics:
 
 - To get started, see the :ref:`{+qe+} Quick Start <qe-quick-start>`.
 - To learn how to use {+qe+}, see the :ref:`{+qe+} Fundamentals <qe-fundamentals>`.
-- To learn how to integrate your implementation with a KMS, see the {+qe+} :ref:`{+qe+} Tutorials <qe-tutorials>`.
+- To learn how to integrate your implementation with a KMS, see the :ref:`{+qe+} Tutorials <qe-tutorials>`.
 - To learn {+qe+} concepts, see the :ref:`{+qe+} Reference <qe-reference>`.
 
 {+csfle-long+}


### PR DESCRIPTION
# Pull Request Info

Updated :v6: links on encrypt page to use :ref:s

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-24285
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-24285/fundamentals/encrypt-fields/

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Are all the links working?
