### PR TITLE
fix typo on encrypt fields page (#379)

### DIFF
--- a/source/fundamentals/encrypt-fields.txt
+++ b/source/fundamentals/encrypt-fields.txt
@@ -66,5 +66,6 @@ The MongoDB manual contains detailed information on the following {+csfle-short+
 - To get started, see the :ref:`{+csfle-short+} Quick Start <csfle-quick-start>`.
 - To learn how to use {+csfle-short+}, see the :ref:`{+csfle-short+} Fundamentals <csfle-fundamentals>`.
 - To learn how to integrate your {+csfle-short+} implementation with a KMS, see the :ref:`{+csfle-short+} Tutorials <csfle-tutorials>`.
-- To learn :{+csfle-short+} concepts, see the :ref:`{+csfle-short+} Reference <csfle-reference>`.
+- To learn {+csfle-short+} concepts, see the :ref:`{+csfle-short+} Reference <csfle-reference>`.
+
 


### PR DESCRIPTION
(cherry picked from commit 46040820f4cea965c87a680d391f780f47b142ee)

# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

Backport of https://github.com/mongodb/docs-node/pull/379

Staging - https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/v4.8/fundamentals/encrypt-fields/#queryable-encryption

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
