### PR TITLE
DOCSP-25723 Updates to Mutually Recursive Schema Types

### DIFF
--- a/source/fundamentals/typescript.txt
+++ b/source/fundamentals/typescript.txt
@@ -44,8 +44,7 @@ For more information on object types, see the
 Type Parameters that Extend Document
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following classes accept all types that both extend
-the ``Document`` interface and are not mutually recursive:
+The following classes accept all types that extend the ``Document`` interface:
 
 .. _node-mongodb-type-parameters-extend-document:
 
@@ -71,14 +70,13 @@ You can pass a type parameter that extends the ``Document`` interface like this:
       :start-after: start-no-key
       :end-before: end-no-key
 
-To view an example of a mutually recursive type, which is not supported by the
-:ref:`preceding classes <node-mongodb-type-parameters-extend-document>`,
-see the :ref:`<node-driver-limitations-mutual-recursion>` section.
+To view an example of a mutually recursive type, see the 
+:ref:`<node-driver-limitations-mutual-recursion>` section.
 
 Type Parameters of Any Type
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following classes accept all type parameters that are not mutually recursive:
+The following classes accept all type parameters:
 
 .. _node-mongodb-type-parameters-any-type:
 
@@ -89,9 +87,8 @@ You can find a code snippet that shows how to specify a type for the ``FindCurso
 class in the
 :ref:`Find Multiple Documents Usage Example <node-driver-find-usage-example-code-snippet>`.
 
-To view an example of a mutually recursive type, which is not supported by the
-:ref:`preceding classes <node-mongodb-type-parameters-any-type>`,
-see the :ref:`<node-driver-limitations-mutual-recursion>` section.
+To view an example of a mutually recursive type, see the 
+:ref:`<node-driver-limitations-mutual-recursion>` section.
 
 
 Type Safety and Dot Notation

--- a/source/fundamentals/typescript.txt
+++ b/source/fundamentals/typescript.txt
@@ -70,9 +70,6 @@ You can pass a type parameter that extends the ``Document`` interface like this:
       :start-after: start-no-key
       :end-before: end-no-key
 
-To view an example of a mutually recursive type, see the 
-:ref:`<node-driver-limitations-mutual-recursion>` section.
-
 Type Parameters of Any Type
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -86,9 +83,6 @@ The following classes accept all type parameters:
 You can find a code snippet that shows how to specify a type for the ``FindCursor``
 class in the
 :ref:`Find Multiple Documents Usage Example <node-driver-find-usage-example-code-snippet>`.
-
-To view an example of a mutually recursive type, see the 
-:ref:`<node-driver-limitations-mutual-recursion>` section.
 
 
 Type Safety and Dot Notation

--- a/source/includes/limitations/limits.rst
+++ b/source/includes/limitations/limits.rst
@@ -1,20 +1,15 @@
 Learn about the following TypeScript specific limitations of the {+driver-short+}:
 
 - :ref:`No type safety for dot notation references to nested instances of recursive types <node-driver-recursive-types-dot-notation>`
-- :ref:`No mutually recursive types <node-driver-limitations-mutual-recursion>`
+- :ref:`Mutually recursive types  <node-driver-limitations-mutual-recursion>`
 
 .. _node-driver-recursive-types-dot-notation:
 
 Recursive Types and Dot Notation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. important:: Impacted Versions
-
-   - 4.3
-   - 4.4
-
-The {+driver-short+} cannot provide type safety within nested instances of
-**recursive types** referenced through dot notation.
+Starting in version 4.3, the {+driver-short+} cannot provide type safety within 
+nested instances of **recursive types** referenced through dot notation.
 
 A recursive type is a type that references itself. You can update
 the :ref:`Pet <mongodb-node-typescript-pet-interface>` interface
@@ -80,18 +75,14 @@ in the MongoDB manual.
 Mutual Recursion
 ~~~~~~~~~~~~~~~~
 
-.. important:: Impacted Versions
-
-   - 4.3
-   - 4.4
-
-You cannot specify a **mutually recursive** type as a type parameter.
+In versions 4.3 through 4.10 of the {+driver-short+}, you cannot specify a 
+**mutually recursive** type as a type parameter. To specify a mutually 
+recursive type as a type parameter, use version 4.11 or newer.
 
 A mutually recursive type exists when two types contain a property that is of
-the other's type. You can update the
-:ref:`Pet <mongodb-node-typescript-pet-interface>` interface
-to be mutually recursive by allowing a pet to have a handler, and defining a
-handler to have a pet. The following are the mutually
+the other's type. You can update the :ref:`Pet <mongodb-node-typescript-pet-interface>` 
+interface to be mutually recursive by allowing a pet to have a handler, and 
+defining a handler to have a pet. The following examples reference the mutually
 recursive ``Pet`` and ``Handler`` interfaces:
 
 .. code-block:: typescript
@@ -107,13 +98,35 @@ recursive ``Pet`` and ``Handler`` interfaces:
       pet: MutuallyRecursivePet;
       name: string;
    }
+   
+The {+driver-short+} provides type safety for mutually recursive types 
+referenced through dot notation up to a depth of eight. The following code 
+snippet assigns a ``string`` to a ``number`` and raises a type error because 
+the referenced property is at a depth of four: 
 
-If you specify a mutually recursive type, the TypeScript compiler raises the
-following error:
+.. code-block:: typescript
+   :emphasize-lines: 3
+
+   database
+      .collection<RecursivePet>("<your collection>")
+      .findOne({'handler.pet.handler.pet.age': "four"});
+
+The error raised by the preceding code snippet is as follows:
 
 .. code-block:: none
 
-   error TS2615: Type of property 'r' circularly references itself in mapped type '{ [Key in keyof MutuallyRecursive]...
+   index.ts(19,59): error TS2769: No overload matches this call.
+   The last overload gave the following error.
+   Type 'string' is not assignable to type 'Condition<number> | undefined'.
 
-If you must apply a mutually recursive type to your classes, use version 4.2 of
-the {+driver-short+}.
+At a depth greater than or equal to eight, TypeScript compiles your code but no
+longer type checks it. The following code assigns a ``string`` to a ``number``
+property but does not cause a compilation error because the referenced property 
+is at a depth of 10:
+
+.. code-block:: typescript
+   :emphasize-lines: 3
+
+   database
+      .collection<RecursivePet>("<your collection>")
+      .findOne({'handler.pet.handler.pet.handler.pet.handler.pet.handler.pet.age': "four"});

--- a/source/includes/limitations/limits.rst
+++ b/source/includes/limitations/limits.rst
@@ -8,8 +8,8 @@ Learn about the following TypeScript specific limitations of the {+driver-short+
 Recursive Types and Dot Notation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Starting in version 4.3, the {+driver-short+} cannot provide type safety within 
-nested instances of **recursive types** referenced through dot notation.
+The {+driver-short+} cannot provide type safety within nested instances of 
+**recursive types** referenced through dot notation.
 
 A recursive type is a type that references itself. You can update
 the :ref:`Pet <mongodb-node-typescript-pet-interface>` interface
@@ -75,11 +75,7 @@ in the MongoDB manual.
 Mutual Recursion
 ~~~~~~~~~~~~~~~~
 
-In versions 4.3 through 4.10 of the {+driver-short+}, you cannot specify a 
-**mutually recursive** type as a type parameter. To specify a mutually 
-recursive type as a type parameter, use version 4.11 or newer.
-
-A mutually recursive type exists when two types contain a property that is of
+A  **mutually recursive**  type exists when two types contain a property that is of
 the other's type. You can update the :ref:`Pet <mongodb-node-typescript-pet-interface>` 
 interface to be mutually recursive by allowing a pet to have a handler, and 
 defining a handler to have a pet. The following examples reference the mutually

--- a/source/includes/limitations/limits.rst
+++ b/source/includes/limitations/limits.rst
@@ -1,7 +1,7 @@
 Learn about the following TypeScript specific limitations of the {+driver-short+}:
 
 - :ref:`No type safety for dot notation references to nested instances of recursive types <node-driver-recursive-types-dot-notation>`
-- :ref:`Type safety depth limitations for mutually recursive types <node-driver-limitations-mutual-recursion>`
+- :ref:`Depth limitations on type safety for mutually recursive types <node-driver-limitations-mutual-recursion>`
 
 .. _node-driver-recursive-types-dot-notation:
 

--- a/source/includes/limitations/limits.rst
+++ b/source/includes/limitations/limits.rst
@@ -89,7 +89,7 @@ recursive ``Pet`` and ``Handler`` interfaces:
    :emphasize-lines: 2, 8
 
    interface Pet {
-      handler: Handler;
+      handler?: Handler;
       name: string;
       age: number;
    }
@@ -108,7 +108,7 @@ the referenced property is at a depth of four:
    :emphasize-lines: 3
 
    database
-      .collection<RecursivePet>("<your collection>")
+      .collection<Pet>("<your collection>")
       .findOne({'handler.pet.handler.pet.age': "four"});
 
 The error raised by the preceding code snippet is as follows:
@@ -128,5 +128,5 @@ is at a depth of 10:
    :emphasize-lines: 3
 
    database
-      .collection<RecursivePet>("<your collection>")
+      .collection<Pet>("<your collection>")
       .findOne({'handler.pet.handler.pet.handler.pet.handler.pet.handler.pet.age': "four"});

--- a/source/includes/limitations/limits.rst
+++ b/source/includes/limitations/limits.rst
@@ -1,7 +1,7 @@
 Learn about the following TypeScript specific limitations of the {+driver-short+}:
 
 - :ref:`No type safety for dot notation references to nested instances of recursive types <node-driver-recursive-types-dot-notation>`
-- :ref:`Mutually recursive types  <node-driver-limitations-mutual-recursion>`
+- :ref:`Type safety depth limitations for mutually recursive types <node-driver-limitations-mutual-recursion>`
 
 .. _node-driver-recursive-types-dot-notation:
 

--- a/source/includes/limitations/limits.rst
+++ b/source/includes/limitations/limits.rst
@@ -88,14 +88,14 @@ recursive ``Pet`` and ``Handler`` interfaces:
 .. code-block:: typescript
    :emphasize-lines: 2, 8
 
-   interface MutuallyRecursivePet {
-      handler?: Handler;
+   interface Pet {
+      handler: Handler;
       name: string;
       age: number;
    }
 
    interface Handler {
-      pet: MutuallyRecursivePet;
+      pet: Pet;
       name: string;
    }
    

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -108,7 +108,7 @@ referenced property is at a depth of 10:
    :copyable: false
 
    collection.findOne({
-       ''bestBook.author.bestBook.author.bestBook.author.bestBook.author.bestBook.author.name': 25
+       'bestBook.author.bestBook.author.bestBook.author.bestBook.author.bestBook.author.name': 25
    })
 
 To learn more, see the `v4.11.0 Release Highlights <https://github.com/mongodb/node-mongodb-native/releases/tag/v4.11.0>`__.

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -64,46 +64,50 @@ To learn more, see the `v4.12.0 Release Highlights <https://github.com/mongodb/n
 What's New in 4.11
 ------------------
 
-The 4.11 {+driver-short+} release includes **recursive schema support**,
-meaning that you can use recursive types as the schema in the
-``Collection`` class. The driver also provides type safety for dot
-notation queries up to a depth of nine in this release. Typescript compiles
-your code beyond a depth of nine, but types fall back to ``any`` at
-this level. The recursive type depth limit is a current limitation in
-TypeScript.
+The 4.11 {+driver-short+} release includes added support for **mutually 
+recursive** collection schema types. The driver also provides type safety for 
+dot notation queries up to a depth of eight in this release. Typescript compiles 
+your code beyond a depth of eight, but types fall back to ``any`` at this level. 
+The recursive type depth limit is a current limitation in TypeScript.
 
-Recursive Schema Type Checking Example
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Mutually Recursive Schema Type Checking Example
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Suppose we have a collection of type ``Collection<CircularSchema>``:
+Suppose we have a collection of type ``Collection<Author>`` which contains the 
+following mutually recursive types:
 
 .. code-block:: js
    :copyable: false
 
-   interface CircularSchema {
+   interface Author {
        name: string;
-       ref: CircularSchema;
+       bestBook: Book;
    }
 
-TypeScript enforces type checking below a depth of nine. The following
+   interface Book { 
+       title: string;
+       author: Author;
+    }
+
+TypeScript enforces type checking below a depth of eight. The following
 code causes a TypeScript compilation error because the ``name`` property
 value must be a ``string`` type:
 
 .. code-block:: js
    :copyable: false
 
-   collection.findOne({ 'ref.ref.ref.name': 25 })
+   collection.findOne({ 'bestBook.author.bestBook.title': 25 })
 
-At a depth greater than nine, TypeScript compiles your code but no
-longer type checks it. The following code assigns an ``int`` to a ``string``
+At a depth greater than or equal to eight, TypeScript compiles your code but no
+longer type checks it. The following code assigns a ``number`` to a ``string``
 property but does not cause a compilation error because the
-referenced property is at a depth of 11:
+referenced property is at a depth of 10:
 
 .. code-block:: js
    :copyable: false
 
    collection.findOne({
-       'ref.ref.ref.ref.ref.ref.ref.ref.ref.ref.name': 25
+       ''bestBook.author.bestBook.author.bestBook.author.bestBook.author.bestBook.author.name': 25
    })
 
 To learn more, see the `v4.11.0 Release Highlights <https://github.com/mongodb/node-mongodb-native/releases/tag/v4.11.0>`__.

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -66,14 +66,15 @@ What's New in 4.11
 
 The 4.11 {+driver-short+} release includes added support for **mutually 
 recursive** collection schema types. The driver also provides type safety for 
-dot notation queries up to a depth of eight in this release. Typescript compiles 
-your code beyond a depth of eight, but types fall back to ``any`` at this level. 
-The recursive type depth limit is a current limitation in TypeScript.
+dot notation queries up to a depth of eight in this release. At a depth greater 
+than or equal to eight, Typescript successfully compiles your code but does not 
+provide type safety because all type checking defaults to ``any`` at this 
+level. This depth limit is a current limitation in TypeScript.
 
 Mutually Recursive Schema Type Checking Example
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Suppose we have a collection of type ``Collection<Author>`` which contains the 
+Suppose we have a collection of type ``Collection<Author>`` that contains the 
 following mutually recursive types:
 
 .. code-block:: js
@@ -89,7 +90,7 @@ following mutually recursive types:
        author: Author;
     }
 
-TypeScript enforces type checking below a depth of eight. The following
+TypeScript enforces type checking up to a depth of eight. The following
 code causes a TypeScript compilation error because the ``name`` property
 value must be a ``string`` type:
 
@@ -99,8 +100,8 @@ value must be a ``string`` type:
    collection.findOne({ 'bestBook.author.bestBook.title': 25 })
 
 At a depth greater than or equal to eight, TypeScript compiles your code but no
-longer type checks it. The following code assigns a ``number`` to a ``string``
-property but does not cause a compilation error because the
+longer type checks it. For example, the following code assigns a ``number`` to a 
+``string`` property but does not cause a compilation error because the
 referenced property is at a depth of 10:
 
 .. code-block:: js

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -66,10 +66,10 @@ What's New in 4.11
 
 The 4.11 {+driver-short+} release includes added support for **mutually 
 recursive** collection schema types. The driver also provides type safety for 
-dot notation queries up to a depth of eight in this release. At a depth greater 
+dot-notation queries up to a depth of eight in this release. At a depth greater 
 than or equal to eight, Typescript successfully compiles your code but does not 
-provide type safety because all type checking defaults to ``any`` at this 
-level. This depth limit is a current limitation in TypeScript.
+provide type safety. This depth limit on recursive types is a current limitation 
+of TypeScript.
 
 Mutually Recursive Schema Type Checking Example
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

**Notes**
- Original ticket mentions broad support for recursive schema types, but the original Node PR only reflects changes for mutually recursive schema types
- Changes to be made were discussed in this [Slack thread](https://mongodb.slack.com/archives/C0275HANT8E/p1669835552153679?thread_ts=1669758869.139549&cid=C0275HANT8E) due to incorrectly documented behavior/examples in the Node release notes.

**JIRA** 
<https://jira.mongodb.org/browse/DOCSP-25723>

**Staging** 
- [TypeScript page (Mutual Recursion Limitations)](https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-25723-v4.11-mutually-recursive-schema-types/fundamentals/typescript/#mutual-recursion)
- [What's New in v4.11](https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-25723-v4.11-mutually-recursive-schema-types/whats-new/#what-s-new-in-4.11)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Are all the links working?
