### PR TITLE
DOCSP-27238: typo fix & other cleanup

### DIFF
--- a/source/fundamentals/crud/write-operations/change-a-document.txt
+++ b/source/fundamentals/crud/write-operations/change-a-document.txt
@@ -15,8 +15,8 @@ Change a Document
 Overview
 --------
 
-You can change documents in a MongoDB collection using two distinct
-operation types: **update** and **replace**. Update operations mutate
+You can change documents in a MongoDB collection using either **update**
+or **replace** operations. Update operations mutate
 specified fields in one or more documents and leave other fields and values
 unchanged. Replace operations remove all existing fields in one or more
 documents and substitute them with specified fields and values.
@@ -55,7 +55,7 @@ update operators:
 - ``$unset``: removes fields
 - ``$mul``: multiplies a field value by a specified number
 
-See the MongoDB server manual for a :manual:`complete list of update operators
+See the MongoDB Server manual for a :manual:`complete list of update operators
 and their usage </reference/operator/update-field/>`.
 
 The update operators apply only to the fields associated with them in your
@@ -119,7 +119,7 @@ attempts to perform an update, but if no documents are matched, inserts
 a new document with the specified fields and values.
 
 You cannot modify the ``_id`` field of a document nor change a field to
-a value that violates a unique index constraint. See the MongoDB server manual
+a value that violates a unique index constraint. See the MongoDB Server manual
 for more information on :manual:`unique indexes </core/index-unique/>`.
 
 .. _node-fundamentals-replaceone:
@@ -184,7 +184,7 @@ and the immutable ``_id`` field as follows:
    :copyable: false
 
    {
-      _id: 465,
+      _id: 501,
       item: "Vintage silver flatware set",
       price: 79.15,
       quantity: 1,
@@ -197,5 +197,5 @@ attempts to perform the replacement, but if no documents are matched, it
 inserts a new document with the specified fields and values.
 
 You cannot modify the ``_id`` field of a document nor change a field to
-a value that violates a unique index constraint. See the MongoDB server manual
+a value that violates a unique index constraint. See the MongoDB Server manual
 for more information on :manual:`unique indexes </core/index-unique/>`.

--- a/source/fundamentals/crud/write-operations/change-a-document.txt
+++ b/source/fundamentals/crud/write-operations/change-a-document.txt
@@ -49,11 +49,11 @@ documents use the following format:
 The top level of an update document contains one or more of the following
 update operators:
 
-- ``$set`` - replaces the value of a field with a specified one
-- ``$inc`` - increments or decrements field values
-- ``$rename`` - renames fields
-- ``$unset`` - removes fields
-- ``$mul`` - multiplies a field value by a specified number
+- ``$set``: replaces the value of a field with a specified one
+- ``$inc``: increments or decrements field values
+- ``$rename``: renames fields
+- ``$unset``: removes fields
+- ``$mul``: multiplies a field value by a specified number
 
 See the MongoDB server manual for a :manual:`complete list of update operators
 and their usage </reference/operator/update-field/>`.
@@ -69,58 +69,54 @@ update document.
    aggregation pipelines used in update operations, see our tutorial on building
    :manual:`updates with aggregation pipelines </tutorial/update-documents-with-aggregation-pipeline/>`.
 
-
 Example
 ~~~~~~~
 
-Consider a document of fields containing the English alphabet of lowercase
-letters ``a`` through ``z`` and their ordinal values:
+Consider a document with fields describing an item for sale, its price,
+and quantity available:
 
 .. code-block:: javascript
 
    {
       _id: 465,
-      a: 1,
-      b: 2,
-      c: 3,
-      ...
-      y: 25,
-      z: 26,
+      item: "Hand-thrown ceramic plate",
+      price: 32.50,
+      quantity: 7,
    }
 
-If you apply the ``$set`` update operator with a specified value for ``z``,
-your update operation might resemble the following:
+If you apply the ``$set`` update operator with a new value for
+``quantity``, you can use the following update document:
 
 .. code-block:: javascript
 
    const filter = { _id: 465 };
-   // update the value of the 'z' field to 42
+
+   // update the value of the 'quantity' field to 5
    const updateDocument = {
       $set: {
-         z: 42,
+         quantity: 5,
       },
    };
    const result = await collection.updateOne(filter, updateDocument);
 
-The updated document resembles the following, with an an updated value in
-the ``z`` field and all other values unchanged:
+The updated document resembles the following, with an updated value in
+the ``quantity`` field and all other values unchanged:
 
 .. code-block:: javascript
    :copyable: false
 
    {
       _id: 465,
-      a: 1,
-      ...
-      y: 25,
-      z: 42,
+      item: "Hand-thrown ceramic plate",
+      price: 32.50,
+      quantity: 5,
    }
 
 If an update operation fails to match any documents in a collection, it
 does not make any changes. Update operations can be configured to perform
 an :doc:`upsert </fundamentals/crud/write-operations/upsert>` which
 attempts to perform an update, but if no documents are matched, inserts
-a new document.
+a new document with the specified fields and values.
 
 You cannot modify the ``_id`` field of a document nor change a field to
 a value that violates a unique index constraint. See the MongoDB server manual
@@ -133,7 +129,7 @@ Replace
 -------
 
 To perform a replacement operation, create a **replacement document** that
-consists of the fields and values that you would like to insert in your
+consists of the fields and values that you would like to use in your
 **replace** operation. Replacement documents use the following format:
 
 .. code-block:: javascript
@@ -153,31 +149,31 @@ existing documents that match the query filters.
 Example
 ~~~~~~~
 
-Consider a document of fields containing the English alphabet of lowercase
-letters ``a`` through ``z`` and their ordinal values:
+Consider a document with fields describing an item for sale, its price,
+and quantity available:
 
 .. code-block:: javascript
 
    {
-      _id: 465,
-      a: 1,
-      b: 2,
-      c: 3,
-      ...
-      y: 25,
-      z: 26,
+      _id: 501,
+      item: "3-wick beeswax candle",
+      price: 18.99,
+      quantity: 10,
    }
 
-Suppose you wanted to replace this document with one that contains only
-the field ``z`` with a value of ``42``. Your replacement operation might
+Suppose you wanted to replace this document with one that contains a
+description for an entirely different item. Your replacement operation might
 resemble the following:
 
 .. code-block:: javascript
 
-   const filter = { _id: 465 };
+   const filter = { _id: 501 };
+
    // replace the matched document with the replacement document
    const replacementDocument = {
-      z: 42,
+      item: "Vintage silver flatware set",
+      price: 79.15,
+      quantity: 1,
    };
    const result = await collection.replaceOne(filter, replacementDocument);
 
@@ -189,14 +185,16 @@ and the immutable ``_id`` field as follows:
 
    {
       _id: 465,
-      z: 42,
+      item: "Vintage silver flatware set",
+      price: 79.15,
+      quantity: 1,
    }
 
 If a replace operation fails to match any documents in a collection, it
 does not make any changes. Replace operations can be configured to perform
 an :doc:`upsert </fundamentals/crud/write-operations/upsert>` which
 attempts to perform the replacement, but if no documents are matched, it
-inserts a new document.
+inserts a new document with the specified fields and values.
 
 You cannot modify the ``_id`` field of a document nor change a field to
 a value that violates a unique index constraint. See the MongoDB server manual


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-27238
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-27238-typo-fix/fundamentals/crud/write-operations/change-a-document/

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?

**In addition to the typo fix I made some changes for clarity and changed the examples to be less confusing**