### PR TITLE
[v4.13] DOCSP-27405: fix insertOne method in the quick reference (#471)

### DIFF
--- a/source/quick-reference.txt
+++ b/source/quick-reference.txt
@@ -69,7 +69,7 @@ their related reference and API documentation.
      - .. code-block:: javascript
           :copyable: true
 
-          await coll.insert({ title: 'Jackie Robinson' });
+          await coll.insertOne({ title: 'Jackie Robinson' });
 
    * - | **Insert Multiple Documents**
        |


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v4.13`:
 - [DOCSP-27405: fix insertOne method in the quick reference (#471)](https://github.com/mongodb/docs-node/pull/471)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)