### PR TITLE
DOCSP-27263: remove references to deprecated helper methods

### DIFF
--- a/source/fundamentals/promises.txt
+++ b/source/fundamentals/promises.txt
@@ -41,7 +41,7 @@ Promises and related terminology, see the MDN documentation on
 :mdn:`Promises <Web/JavaScript/Reference/Global_Objects/Promise>`.
 
 Most driver methods that communicate with your MongoDB cluster such as
-``findOneAndUpdate()``, ``countDocuments()``, and ``update()`` return Promise
+``findOneAndUpdate()`` and ``countDocuments()`` return Promise
 objects and already contain logic to handle the success or failure of the
 operation.
 

--- a/source/fundamentals/promises.txt
+++ b/source/fundamentals/promises.txt
@@ -40,8 +40,8 @@ still running, **Fulfilled** if the operation completed successfully, and
 Promises and related terminology, see the MDN documentation on
 :mdn:`Promises <Web/JavaScript/Reference/Global_Objects/Promise>`.
 
-Most driver methods that communicate with your MongoDB cluster such as
-``findOneAndUpdate()`` and ``countDocuments()`` return Promise
+Most driver methods that communicate with your MongoDB cluster, such as
+``findOneAndUpdate()`` and ``countDocuments()``, return Promise
 objects and already contain logic to handle the success or failure of the
 operation.
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-27263
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-27263-remove-helpers/fundamentals/promises/

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
