### PR TITLE
DOCSP-27376: removed support for dot notation in find*

### DIFF
--- a/source/fundamentals/typescript.txt
+++ b/source/fundamentals/typescript.txt
@@ -116,22 +116,33 @@ instead of a string:
 
    await collection.findOneAndDelete({ "classification.color": false })
 
-You can enable type-checking by constructing filters as ``StrictFilter`` types.
+You can enable type-checking by constructing filters as ``StrictFilter`` or
+``StrictUpdateFilter`` types.
 
 .. warning::
    
-   Use of the ``StrictFilter`` type to create filters is experimental and currently has
-   unknown performance implications.
+   Use of the ``StrictFilter`` and ``StrictUpdateFilter`` types to create filters
+   is experimental and may show type errors in valid queries where there should 
+   be none.
 
 In the following code sample, the filter is assigned a
 ``StrictFilter`` type. Given this filter type, the {+driver-short+}
 reports a type error because the value of ``classification.color`` is a
-boolean instead of a string:
+boolean instead of a string.
 
 .. code-block:: typescript
 
    const filterPredicate: StrictFilter<ClassificationPet> = { "classification.color": false };
    await collection.findOneAndDelete(filterPredicate);
+
+The following example assigns a ``StrictUpdateFilter`` type to an update
+filter. The {+driver-short+} reports a type error because the value of
+``classification.color`` is a boolean instead of a string.
+
+.. code-block:: typescript
+   
+   const updateFilter: StrictUpdateFilter<ClassificationPet> = { $set: { "classification.color": false } }
+   await pets.updateOne({}, updateFilter);
 
 Referencing Keys that Incorporate Variables
 ```````````````````````````````````````````

--- a/source/fundamentals/typescript.txt
+++ b/source/fundamentals/typescript.txt
@@ -84,11 +84,13 @@ You can find a code snippet that shows how to specify a type for the ``FindCurso
 class in the
 :ref:`Find Multiple Documents Usage Example <node-driver-find-usage-example-code-snippet>`.
 
+.. _node-ts-type-safety:
+
 Type Safety and Dot Notation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you specify a query or update with **dot notation**, the {+driver-short+}
-provides type safety if your query or update does not
+If you specify an update with **dot notation**, the {+driver-short+}
+provides type safety if your update does not
 :ref:`reference a nested instance of a recursive type <node-driver-recursive-types-dot-notation>`.
 Dot notation is a syntax you can use to navigate nested JSON objects.
 
@@ -104,22 +106,53 @@ genus and color of dogs and cats:
      classification: { genus: "Canis" | "Felis"; color: string };
    }
 
-The following code snippet correctly raises a type error when specifying
-the genus of an unsupported animal in a query:
+The following code snippet correctly raises a type error when setting
+the ``classification.color`` to a ``number`` type in an update
+operation:
 
 .. code-block:: typescript
 
-   database
-     .collection<ClassificationPet>("<your collection>")
-     .find({ "classification.genus": "Sylvilagus" });
+   await collection.updateOne({ name: "Garfield" }, { $set: { "classification.color": 101 } });
 
 The type error raised by the preceding code snippet is as follows:
 
 .. code-block:: none
 
-   No overload matches this call.
-   ...
-   Type '"Sylvilagus"' is not assignable to type 'Condition<"Canis" | "Felis">'.
+   Type 'number' is not assignable to type 'string'.
+   
+Dot Notation in Find Operations
+```````````````````````````````
+
+Starting in version 5.0, the {+driver-short+} does not provide type
+safety for *find operations* that search on fields expressed in dot
+notation. When you construct a filter to pass to a find method, such as
+``find()`` or ``findOneAndUpdate()``, your code compiles even if you
+specify a value of an incorrect type for a field expressed in dot
+notation.
+
+The following code compiles, even though the value of
+``classification.color`` should be a string:
+
+.. code-block:: typescript
+
+   await collection.find({ "classification.color": false })
+
+Even though support for this checking is removed by default, you can
+enable type-checking by constructing filters as ``StrictFilter`` types.
+
+.. warning::
+   
+   Use of the ``StrictFilter`` type to create filters is experimental and currently has
+   unknown performance implications.
+
+The following code does not compile because the filter is assigned as a
+``StrictFilter`` type, which causes the driver to report a type error
+because the value of ``classification.color`` should be a string:
+
+.. code-block:: typescript
+
+   const filterPredicate: StrictFilter<ClassificationPet> = { "classification.color": false };
+   collection.find(filterPredicate);
 
 Referencing Keys that Incorporate Variables
 ```````````````````````````````````````````

--- a/source/fundamentals/typescript.txt
+++ b/source/fundamentals/typescript.txt
@@ -123,36 +123,46 @@ The type error raised by the preceding code snippet is as follows:
 Dot Notation in Find Operations
 ```````````````````````````````
 
-Starting in version 5.0, the {+driver-short+} does not provide type
-safety for *find operations* that search on fields expressed in dot
-notation. When you construct a filter to pass to a find method, such as
-``find()`` or ``findOneAndUpdate()``, your code compiles even if you
-specify a value of an incorrect type for a field expressed in dot
-notation.
+Starting in version 5.0, by default, the {+driver-short+} does not provide type
+safety for find operations that search on fields expressed in dot
+notation. When you construct a filter to pass to a find method, the
+driver will not raise a type error even if you specify an incorrectly
+typed value for a field expressed in dot notation.
 
-The following code compiles, even though the value of
-``classification.color`` should be a string:
+.. note::
+
+   The following methods comprise find operations:
+
+   - ``find()``
+   - ``findOne()``
+   - ``findOneAndDelete()``
+   - ``findOneAndReplace()``
+   - ``findOneAndUpdate()``
+
+The driver does not raise a type error for the following code sample,
+even though the value of ``classification.color`` is a boolean
+instead of a string:
 
 .. code-block:: typescript
 
-   await collection.find({ "classification.color": false })
+   await collection.findOneAndDelete({ "classification.color": false })
 
-Even though support for this checking is removed by default, you can
-enable type-checking by constructing filters as ``StrictFilter`` types.
+You can enable type-checking by constructing filters as ``StrictFilter`` types.
 
 .. warning::
    
    Use of the ``StrictFilter`` type to create filters is experimental and currently has
    unknown performance implications.
 
-The following code does not compile because the filter is assigned as a
-``StrictFilter`` type, which causes the driver to report a type error
-because the value of ``classification.color`` should be a string:
+In the following code sample, the filter is assigned a
+``StrictFilter`` type.  Given this filter type, the {+driver-short+}
+reports a type error because the value of ``classification.color`` is a
+boolean instead of a string:
 
 .. code-block:: typescript
 
    const filterPredicate: StrictFilter<ClassificationPet> = { "classification.color": false };
-   collection.find(filterPredicate);
+   await collection.findOneAndDelete(filterPredicate);
 
 Referencing Keys that Incorporate Variables
 ```````````````````````````````````````````

--- a/source/fundamentals/typescript.txt
+++ b/source/fundamentals/typescript.txt
@@ -131,7 +131,7 @@ typed value for a field expressed in dot notation.
 
 .. note::
 
-   The following methods comprise find operations:
+   The following methods exhibit this behavior:
 
    - ``find()``
    - ``findOne()``

--- a/source/fundamentals/typescript.txt
+++ b/source/fundamentals/typescript.txt
@@ -96,6 +96,18 @@ you construct a filter to pass to a query, the driver will not raise a
 type error even if you specify an incorrectly typed value for a field expressed
 in dot notation.
 
+The following code snippet defines the ``ClassificationPet`` interface,
+which includes a ``classification`` field that enables you to specify the
+genus and color of dogs and cats:
+
+.. code-block:: typescript
+
+   interface ClassificationPet {
+     name: string;
+     age: number;
+     classification: { genus: "Canis" | "Felis"; color: string };
+   }
+
 The driver does not raise a type error for the following code sample,
 even though the value of ``classification.color`` is a boolean
 instead of a string:

--- a/source/fundamentals/typescript.txt
+++ b/source/fundamentals/typescript.txt
@@ -121,9 +121,8 @@ You can enable type-checking by constructing filters as ``StrictFilter`` or
 
 .. warning::
    
-   Use of the ``StrictFilter`` and ``StrictUpdateFilter`` types to create filters
-   is experimental and may show type errors in valid queries where there should 
-   be none.
+   The ``StrictFilter`` and ``StrictUpdateFilter`` types are experimental and
+   may show type errors in valid queries where there should be none.
 
 In the following code sample, the filter is assigned a
 ``StrictFilter`` type. Given this filter type, the {+driver-short+}

--- a/source/fundamentals/typescript.txt
+++ b/source/fundamentals/typescript.txt
@@ -89,55 +89,12 @@ class in the
 Type Safety and Dot Notation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you specify an update with **dot notation**, the {+driver-short+}
-provides type safety if your update does not
-:ref:`reference a nested instance of a recursive type <node-driver-recursive-types-dot-notation>`.
-Dot notation is a syntax you can use to navigate nested JSON objects.
-
-The following code snippet defines the ``ClassificationPet`` interface,
-which includes a ``classification`` field that enables you to specify the
-genus and color of dogs and cats:
-
-.. code-block:: typescript
-
-   interface ClassificationPet {
-     name: string;
-     age: number;
-     classification: { genus: "Canis" | "Felis"; color: string };
-   }
-
-The following code snippet correctly raises a type error when setting
-the ``classification.color`` to a ``number`` type in an update
-operation:
-
-.. code-block:: typescript
-
-   await collection.updateOne({ name: "Garfield" }, { $set: { "classification.color": 101 } });
-
-The type error raised by the preceding code snippet is as follows:
-
-.. code-block:: none
-
-   Type 'number' is not assignable to type 'string'.
-   
-Dot Notation in Find Operations
-```````````````````````````````
-
 Starting in version 5.0, by default, the {+driver-short+} does not provide type
-safety for find operations that search on fields expressed in dot
-notation. When you construct a filter to pass to a find method, the
-driver will not raise a type error even if you specify an incorrectly
-typed value for a field expressed in dot notation.
-
-.. note::
-
-   The following methods exhibit this behavior:
-
-   - ``find()``
-   - ``findOne()``
-   - ``findOneAndDelete()``
-   - ``findOneAndReplace()``
-   - ``findOneAndUpdate()``
+safety for operations that search on fields expressed in **dot notation**. Dot
+notation is a syntax you can use to navigate nested JSON objects. When
+you construct a filter to pass to a query, the driver will not raise a
+type error even if you specify an incorrectly typed value for a field expressed
+in dot notation.
 
 The driver does not raise a type error for the following code sample,
 even though the value of ``classification.color`` is a boolean
@@ -155,7 +112,7 @@ You can enable type-checking by constructing filters as ``StrictFilter`` types.
    unknown performance implications.
 
 In the following code sample, the filter is assigned a
-``StrictFilter`` type.  Given this filter type, the {+driver-short+}
+``StrictFilter`` type. Given this filter type, the {+driver-short+}
 reports a type error because the value of ``classification.color`` is a
 boolean instead of a string:
 

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -46,8 +46,7 @@ New features of the 5.0 {+driver-short+} release include:
 
   - The driver no longer checks types referenced in dot notation during
     find operations unless the ``StrictFilter`` feature is explicitly
-    implemented. To learn more about this change, see the :ref:`
-    Typescript fundamentals page <node-ts-type-safety>`.
+    implemented. To learn more about this change, see the :ref:`Typescript fundamentals page <node-ts-type-safety>`.
 
 - Optional installation of ``@aws-sdk/credential-providers`` as a dependency.
 

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -41,12 +41,9 @@ What's New in 5.0
 
 New features of the 5.0 {+driver-short+} release include:
 
-- Removal of default Typescript type-checking of types expressed in dot
-  notation.
-
-  - The driver no longer checks types referenced in dot notation during
-    find operations unless the ``StrictFilter`` feature is explicitly
-    implemented. To learn more about this change, see the :ref:`Typescript fundamentals page <node-ts-type-safety>`.
+- By default, the driver no longer checks types referenced in dot notation during
+  find operations unless the ``StrictFilter`` feature is explicitly
+  implemented. To learn more about this change, see the :ref:`Typescript fundamentals page <node-ts-type-safety>`.
 
 - Optional installation of ``@aws-sdk/credential-providers`` as a dependency.
 

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -41,6 +41,14 @@ What's New in 5.0
 
 New features of the 5.0 {+driver-short+} release include:
 
+- Removal of default Typescript type-checking of types expressed in dot
+  notation.
+
+  - The driver no longer checks types referenced in dot notation during
+    find operations unless the ``StrictFilter`` feature is explicitly
+    implemented. To learn more about this change, see the :ref:`
+    Typescript fundamentals page <node-ts-type-safety>`.
+
 - Optional installation of ``@aws-sdk/credential-providers`` as a dependency.
 
   - The driver no longer includes AWS SDK modules by default. Use the

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -41,8 +41,8 @@ What's New in 5.0
 
 New features of the 5.0 {+driver-short+} release include:
 
-- By default, the driver no longer checks types referenced in dot notation during
-  find operations unless the ``StrictFilter`` feature is explicitly
+- By default, the driver no longer checks types referenced in dot notation
+  unless the ``StrictFilter`` feature is explicitly
   implemented. To learn more about this change, see the :ref:`Typescript fundamentals page <node-ts-type-safety>`.
 
 - Optional installation of ``@aws-sdk/credential-providers`` as a dependency.

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -42,8 +42,14 @@ What's New in 5.0
 New features of the 5.0 {+driver-short+} release include:
 
 - By default, the driver no longer checks types referenced in dot notation
-  unless the ``StrictFilter`` feature is explicitly
-  implemented. To learn more about this change, see the :ref:`Typescript fundamentals page <node-ts-type-safety>`.
+  unless the ``StrictFilter`` type annotation is explicitly
+  used. To learn more about this change, see the :ref:`Typescript fundamentals
+  page <node-ts-type-safety>`.
+  
+  .. note::
+
+     This change is for Typescript only, and does not affect queries or operations
+     at runtime.
 
 - Optional installation of ``@aws-sdk/credential-providers`` as a dependency.
 
@@ -52,7 +58,7 @@ New features of the 5.0 {+driver-short+} release include:
 
     .. code-block:: bash
 
-       npm install --save @aws-sdk/credential-providers@3.186.0
+       npm install --save "@aws-sdk/credential-providers@^3.201.0"
 
     If you install the SDK, ``npm`` notifies you if the version of the SDK you
     installed is incompatible with the driver. Once you install the


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-27376
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-27376-dot-notation-unsupported/fundamentals/typescript/#type-safety-and-dot-notation
https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-27376-dot-notation-unsupported/whats-new/#what-s-new-in-5.0

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
