### PR TITLE
DOCSP-27863: correct default of connectTimeoutMS

### DIFF
--- a/source/faq.txt
+++ b/source/faq.txt
@@ -63,7 +63,7 @@ What Is the Difference Between "connectTimeoutMS", "socketTimeoutMS" and "maxTim
           To modify the allowed time for `MongoClient.connect <{+api+}/classes/MongoClient.html#connect>`__ to establish a
           connection to a MongoDB server, use the ``serverSelectionTimeoutMS`` option instead.
 
-       **Default:** 10000
+       **Default:** 30000
    * - **socketTimeoutMS**
      - ``socketTimeoutMS`` specifies the amount of time the driver waits
        for an inactive socket before closing it. The default value is to

--- a/source/fundamentals/connection/connection-options.txt
+++ b/source/fundamentals/connection/connection-options.txt
@@ -54,7 +54,7 @@ parameters of the connection URI to specify the behavior of the client.
 
    * - **connectTimeoutMS**
      - non-negative integer
-     - ``10000``
+     - ``30000``
      - Specifies the amount of time, in milliseconds, to wait to establish a single TCP
        socket connection to the server before raising an error. Specifying
        ``0`` disables the connection timeout.


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-27863
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-27863-connectTimeoutMS-correct-default/fundamentals/connection/connection-options/

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
