### PR TITLE
[v4.7] DOCSP-27863: correct default of connectTimeoutMS (#518)

### DIFF
--- a/source/faq.txt
+++ b/source/faq.txt
@@ -63,7 +63,7 @@ What Is the Difference Between "connectTimeoutMS", "socketTimeoutMS" and "maxTim
           To modify the allowed time for `MongoClient.connect <{+api+}/classes/MongoClient.html#connect>`__ to establish a
           connection to a MongoDB server, use the ``serverSelectionTimeoutMS`` option instead.
 
-       **Default:** 10000
+       **Default:** 30000
    * - **socketTimeoutMS**
      - ``socketTimeoutMS`` specifies the amount of time the driver waits
        for an inactive socket before closing it. The default value is to

--- a/source/fundamentals/connection/connection-options.txt
+++ b/source/fundamentals/connection/connection-options.txt
@@ -54,7 +54,7 @@ parameters of the connection URI to specify the behavior of the client.
 
    * - **connectTimeoutMS**
      - non-negative integer
-     - ``10000``
+     - ``30000``
      - Specifies the amount of time, in milliseconds, to wait to establish a single TCP
        socket connection to the server before raising an error. Specifying
        ``0`` disables the connection timeout.


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v4.7`:
 - [DOCSP-27863: correct default of connectTimeoutMS (#518)](https://github.com/mongodb/docs-node/pull/518)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)