### PR TITLE
[v4.14] Docsp 27849 connection monitoring (#531)

### DIFF
--- a/source/code-snippets/monitoring/cpm-subscribe.js
+++ b/source/code-snippets/monitoring/cpm-subscribe.js
@@ -1,0 +1,26 @@
+const { MongoClient } = require("mongodb");
+
+// Replace the following with your MongoDB deployment's connection
+// string.
+const uri =
+  "mongodb+srv://<clusterUrl>/?replicaSet=rs&writeConcern=majority";
+
+const client = new MongoClient(uri);
+
+// Replace <event name> with the name of the event you are subscribing to.
+const eventName = "<event name>";
+client.on(eventName, (event) =>
+  console.log("\nreceived event:\n", event)
+);
+
+async function run() {
+  try {
+    // Establish and verify connection
+    await client.db("admin").command({ ping: 1 });
+    console.log("\nConnected successfully!\n");
+  } finally {
+    // Ensures that the client will close when you finish/error
+    await client.close();
+  }
+}
+run().catch(console.dir);

--- a/source/fundamentals/monitoring.txt
+++ b/source/fundamentals/monitoring.txt
@@ -9,8 +9,11 @@ Monitoring
 
    /fundamentals/monitoring/cluster-monitoring
    /fundamentals/monitoring/command-monitoring
+   /fundamentals/monitoring/connection-monitoring
 
 - :doc:`Cluster Monitoring </fundamentals/monitoring/cluster-monitoring>`: monitoring
   changes in a cluster
 - :doc:`Command Monitoring </fundamentals/monitoring/command-monitoring>`: monitoring
   the execution status of commands
+- :doc:`Connection Pool Monitoring </fundamentals/monitoring/connection-monitoring>`: monitoring
+  the driver's connection pool

--- a/source/fundamentals/monitoring/connection-monitoring.txt
+++ b/source/fundamentals/monitoring/connection-monitoring.txt
@@ -1,0 +1,223 @@
+==========================
+Connection Pool Monitoring
+==========================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecols
+
+Overview
+--------
+
+This guide shows you how to monitor the driver's **connection pool**. A
+connection pool is a set of open TCP connections your driver maintains
+with a MongoDB instance. Connection pools help reduce the number of
+network handshakes your application needs to perform and can help your
+application run faster.
+
+Read this guide if you need to record connection pool events in your
+application or want to explore the information provided in these events.
+
+Event Subscription Example
+--------------------------
+
+You can access one or more connection pool events using the driver by
+subscribing to them in your application. The following example demonstrates
+connecting to a replica set and subscribing to one of the connection
+pool monitoring events created by the MongoDB deployment:
+
+.. literalinclude:: /code-snippets/monitoring/cpm-subscribe.js
+   :language: javascript
+
+Event Descriptions
+------------------
+
+You can subscribe to any of the following connection pool monitoring events:
+
+.. list-table::
+   :widths: 33 67
+   :header-rows: 1
+
+   * - Event Name
+     - Description
+
+   * - ``connectionPoolCreated``
+     - Created when a connection pool is created.
+
+   * - ``connectionPoolReady``
+     - Created when a connection pool is ready.
+
+   * - ``connectionPoolClosed``
+     - Created when a connection pool is closed, prior to server
+       instance destruction.
+
+   * - ``connectionCreated``
+     - Created when a connection is created, but not necessarily
+       when it is used for an operation.
+
+   * - ``connectionReady``
+     - Created after a connection has successfully completed a
+       handshake and is ready to be used for operations.
+
+   * - ``connectionClosed``
+     - Created when a connection is closed.
+
+   * - ``connectionCheckOutStarted``
+     - Created when an operation attempts to acquire a connection for
+       execution.
+
+   * - ``connectionCheckOutFailed``
+     - Created when an operation fails to acquire a connection for
+       execution.
+
+   * - ``connectionCheckedOut``
+     - Created when an operation successfully acquires a connection for
+       execution.
+
+   * - ``connectionCheckedIn``
+     - Created when a connection is checked back into the pool after an operation
+       is executed.
+
+   * - ``connectionPoolCleared``
+     - Created when a connection pool is cleared.
+
+Example Event Documents
+-----------------------
+
+The following sections show sample output for each type of connection
+pool monitoring event.
+
+connectionPoolCreated
+~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: none
+   :copyable: false
+
+   ConnectionPoolCreatedEvent {
+     time: 2023-02-13T15:54:06.944Z,
+     address: '...',
+     options: {...}
+   }
+
+connectionPoolReady
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: none
+   :copyable: false
+
+   ConnectionPoolReadyEvent {
+     time: 2023-02-13T15:56:38.440Z,
+     address: '...'
+   }
+
+connectionPoolClosed
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: none
+   :copyable: false
+
+   ConnectionPoolClosedEvent {
+     time: 2023-02-13T15:56:38.440Z,
+     address: '...'
+   }
+
+connectionCreated
+~~~~~~~~~~~~~~~~~
+
+.. code-block:: none
+   :copyable: false
+
+   ConnectionCreatedEvent {
+     time: 2023-02-13T15:56:38.291Z,
+     address: '...',
+     connectionId: 1
+   }
+
+connectionReady
+~~~~~~~~~~~~~~~
+
+.. code-block:: none
+   :copyable: false
+
+   ConnectionReadyEvent {
+     time: 2023-02-13T15:56:38.291Z,
+     address: '...',
+     connectionId: 1
+   }
+
+connectionClosed
+~~~~~~~~~~~~~~~~
+
+.. code-block:: none
+   :copyable: false
+
+   ConnectionClosedEvent {
+     time: 2023-02-13T15:56:38.439Z,
+     address: '...',
+     connectionId: 1,
+     reason: 'poolClosed',
+     serviceId: undefined
+   }
+
+connectionCheckOutStarted
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: none
+   :copyable: false
+
+   ConnectionCheckOutStartedEvent {
+     time: 2023-02-13T15:56:38.291Z,
+     address: '...',
+   }
+
+connectionCheckOutFailed
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: none
+   :copyable: false
+
+   ConnectionCheckOutFailedEvent {
+     time: 2023-02-13T15:56:38.291Z,
+     address: '...',
+     reason: ...
+   }
+
+connectionCheckedOut
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: none
+   :copyable: false
+
+   ConnectionCheckedOutEvent {
+     time: 2023-02-13T15:54:07.188Z,
+     address: '...',
+     connectionId: 1
+   }
+
+connectionCheckedIn
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: none
+   :copyable: false
+
+   ConnectionCheckedInEvent {
+     time: 2023-02-13T15:54:07.189Z,
+     address: '...',
+     connectionId: 1
+   }
+
+connectionPoolCleared
+~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: none
+   :copyable: false
+
+   ConnectionPoolClearedEvent {
+     time: 2023-02-13T15:56:38.439Z,
+     address: '...',
+     serviceId: undefined,
+     interruptInUseConnections: true,
+   }
+


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v4.14`:
 - [Docsp 27849 connection monitoring (#531)](https://github.com/mongodb/docs-node/pull/531)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)