### PR TITLE
[v4.2] DOCSP-14352: fix multikey index description & example (#542)

### DIFF
--- a/source/code-snippets/indexes/compound.js
+++ b/source/code-snippets/indexes/compound.js
@@ -24,7 +24,7 @@ async function run() {
     // begin-query
     const query = { type: "movie", genre: "Drama" };
     const sort = { type: 1, genre: 1 };
-    const projection = { type: 1, genre: 1 };
+    const projection = { _id: 0, type: 1, genre: 1 };
 
     const cursor = movies
       .find(query)

--- a/source/code-snippets/indexes/multikey.js
+++ b/source/code-snippets/indexes/multikey.js
@@ -15,22 +15,21 @@ async function run() {
     const database = client.db("sample_mflix");
     const movies = database.collection("movies");
 
-    // Create a multikey index on the "cast" array field
-    // in the "movies" collection.
+    // Create a multikey index on the "cast" field
     const result = await movies.createIndex({ cast: 1 });
-    console.log(`Index created: ${result}`);
     // end-idx
 
+    console.log(`Index created: ${result}`);
+
     // begin-query
-    const query = { cast: "Burt Reynolds" };
-    const sort = { cast: 1, genre: 1 };
-    const projection = { cast: 1 };
+    const query = { cast: "Viola Davis" };
+    const projection = { _id: 0, cast: 1 , title: 1 };
 
     const cursor = movies
       .find(query)
-      .sort(sort)
       .project(projection);
     // end-query
+
   } finally {
     await client.close();
   }

--- a/source/code-snippets/indexes/single-field.js
+++ b/source/code-snippets/indexes/single-field.js
@@ -24,7 +24,7 @@ async function run() {
     // begin-query
     const query = { title: "Batman" }
     const sort = { title: 1 };
-    const projection = { title: 1 };
+    const projection = { _id: 0, title: 1 };
 
     const cursor = movies
       .find(query)

--- a/source/code-snippets/indexes/text.js
+++ b/source/code-snippets/indexes/text.js
@@ -23,7 +23,7 @@ async function run() {
 
     // begin-query
     const query = { $text: { $search: "java coffee shop" } };
-    const projection = { fullplot: 1 };
+    const projection = { _id: 0, fullplot: 1 };
     const cursor = movies
       .find(query)
       .project(projection);

--- a/source/fundamentals/indexes.txt
+++ b/source/fundamentals/indexes.txt
@@ -123,22 +123,21 @@ See the MongoDB server manual section on
 Multikey Indexes (Indexes on Array Fields)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**Multikey indexes** are indexes that improve performance for queries that
-specify ascending or descending indexes on fields that contain an array value.
-You can define a multikey index using the same syntax as a single field or
-compound index.
+**Multikey indexes** are indexes that improve the performance of queries on
+fields that contain array values.
 
-The following example use the ``createIndex()`` method to create an ascending
-index on the ``cast`` field (array of names) in the ``movies`` collection in
-the ``sample_mflix`` database.
+You can create a multikey index on a field with an array value by
+calling the ``createIndex()`` method. The following code creates an ascending
+index on the ``cast`` field in the ``movies`` collection of the
+``sample_mflix`` database:
 
 .. literalinclude:: /code-snippets/indexes/multikey.js
    :language: js
    :start-after: begin-idx
    :end-before: end-idx
 
-The following is an example of a query that would be covered by the index
-created above.
+The following code queries the multikey index to find
+documents with a ``cast`` field value that contains "Viola Davis":
 
 .. literalinclude:: /code-snippets/indexes/multikey.js
    :language: js
@@ -149,7 +148,7 @@ Multikey indexes behave differently from non-multikey indexes in terms of
 query coverage, index bound computation, and sort behavior. For a full
 explanation of multikey indexes, including a discussion of their behavior
 and limitations, refer to the :manual:`Multikey Indexes page
-</core/index-multikey>` in the MongoDB manual.
+</core/index-multikey>` in the MongoDB Server manual.
 
 Text Indexes
 ~~~~~~~~~~~~


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v4.2`:
 - [DOCSP-14352: fix multikey index description & example (#542)](https://github.com/mongodb/docs-node/pull/542)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)