### PR TITLE
[v4.2] docsp-28100 - connection monitoring link (#556)

### DIFF
--- a/source/fundamentals/logging.txt
+++ b/source/fundamentals/logging.txt
@@ -18,8 +18,9 @@ Logging
 
   Instead, see our monitoring guides:
 
-  - :doc:`Command Monitoring </fundamentals/monitoring/command-monitoring>`
-  - :doc:`Cluster Monitoring </fundamentals/monitoring/cluster-monitoring>`
+  - :ref:`Command Monitoring <node-command-monitoring>`
+  - :ref:`Cluster Monitoring <node-cluster-monitoring>`
+  - :ref:`Connection Pool Monitoring <node-connection-pool-monitoring>`
 
 Temporary Alternative
 ---------------------

--- a/source/fundamentals/monitoring/cluster-monitoring.txt
+++ b/source/fundamentals/monitoring/cluster-monitoring.txt
@@ -1,3 +1,5 @@
+.. _node-cluster-monitoring:
+
 ==================
 Cluster Monitoring
 ==================

--- a/source/fundamentals/monitoring/command-monitoring.txt
+++ b/source/fundamentals/monitoring/command-monitoring.txt
@@ -1,3 +1,5 @@
+.. _node-command-monitoring:
+
 ==================
 Command Monitoring
 ==================

--- a/source/fundamentals/monitoring/connection-monitoring.txt
+++ b/source/fundamentals/monitoring/connection-monitoring.txt
@@ -1,3 +1,5 @@
+.. _node-connection-pool-monitoring:
+
 ==========================
 Connection Pool Monitoring
 ==========================

--- a/source/index.txt
+++ b/source/index.txt
@@ -125,6 +125,6 @@ Take the free online course taught by MongoDB instructors
           :alt: Banner for the MongoDB University Node.js Course
 
      - `Using MongoDB with Node.js <https://learn.mongodb.com/learning-paths/using-mongodb-with-nodejs-y13d>`_
-        Learn the essentials of Node.js application development with
-        MongoDB.
+        
+       Learn the essentials of Node.js application development with MongoDB.
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v4.2`:
 - [docsp-28100 - connection monitoring link (#556)](https://github.com/mongodb/docs-node/pull/556)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)