### PR TITLE
[v4.2] docsp-12262 - remove OCSP (#573)

### DIFF
--- a/source/fundamentals/connection/connection-options.txt
+++ b/source/fundamentals/connection/connection-options.txt
@@ -259,18 +259,6 @@ parameters of the connection URI to specify the behavior of the client.
      - Specifies the password to decrypt the client private key to be used
        for TLS connections.
 
-   * - **tlsDisableCertificateRevocationCheck**
-     - boolean
-     - ``false``
-     - Specifies whether the driver will check a certificate's
-       revocation status via CRLs or OCSP.
-
-   * - **tlsDisableOCSPEndpointCheck**
-     - boolean
-     - ``false``
-     - Specifies whether the driver will reach out to OCSP
-       endpoints if needed.
-
    * - **tlsInsecure**
      - boolean
      - ``false``

--- a/source/index.txt
+++ b/source/index.txt
@@ -120,10 +120,9 @@ Take the free online course taught by MongoDB instructors
 
 .. list-table::
 
-   * - .. cssclass:: bordered-figure
-       .. figure:: /includes/figures/M220JS_hero.jpg
+   * - .. figure:: /includes/figures/M220JS_hero.jpg
           :alt: Banner for the MongoDB University Node.js Course
-
+     
      - `Using MongoDB with Node.js <https://learn.mongodb.com/learning-paths/using-mongodb-with-nodejs-y13d>`_
         
        Learn the essentials of Node.js application development with MongoDB.

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -362,7 +362,6 @@ What's New in 3.6
 New features of the 3.6 Node.js driver release include:
 
 - Added support for the :ref:`MONGODB-AWS <mongodb-aws>` authentication mechanism using Amazon Web Services (AWS) Identity and Access Management (IAM) credentials
-- Added support for Online Certificate Status Protocol (OCSP)
 - The `find() <{+api+}/classes/Collection.html#find>`__ method supports ``allowDiskUse()`` for sorts that require too much memory to execute in RAM
 - The :ref:`update() <updateDocuments>` and :ref:`replaceOne() <replacementDocument>` methods support index hints
 - A reduction in recovery time for topology changes and failover events


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v4.2`:
 - [docsp-12262 - remove OCSP (#573)](https://github.com/mongodb/docs-node/pull/573)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)