### PR TITLE
[v4.11] add stableapi connection example (#590)

### DIFF
--- a/source/code-snippets/connection/stable-api-connect.js
+++ b/source/code-snippets/connection/stable-api-connect.js
@@ -1,0 +1,29 @@
+const { MongoClient, ServerApiVersion } = require("mongodb");
+
+// Replace the placeholders with your credentials and hostname
+const uri = "mongodb+srv://<username>:<password>@<hostname>/?retryWrites=true&w=majority";
+
+// Create a MongoClient with a MongoClientOptions object to set the Stable API version
+const client = new MongoClient(uri,  {
+        serverApi: {
+            version: ServerApiVersion.v1,
+            strict: true,
+            deprecationErrors: true,
+        }
+    }
+);
+
+async function run() {
+  try {
+    // Connect the client to the server (optional starting in v4.7)
+    await client.connect();
+
+    // Send a ping to confirm a successful connection
+    await client.db("admin").command({ ping: 1 });
+    console.log("Pinged your deployment. You successfully connected to MongoDB!");
+  } finally {
+    // Ensures that the client will close when you finish/error
+    await client.close();
+  }
+}
+run().catch(console.dir);

--- a/source/fundamentals/connection/connect.txt
+++ b/source/fundamentals/connection/connect.txt
@@ -39,16 +39,16 @@ reconfiguring clients.
    To learn how to retrieve your connection string in Atlas, see the
    :atlas:`Atlas driver connection guide </driver-connection>`.
 
-The next part of the connection string contains your username and password
+The next part of the connection string contains your credentials
 if you are using password-based authentication. Replace the value of ``user``
 with your username and ``pass`` with your password. If you are using an
 authentication mechanism that does not require a username and password, omit
 this part of the connection URI.
 
-The next part of the connection string specifies the hostname or IP address and
-port of your MongoDB instance. In the example above, we use ``sample.host``
-as the hostname and ``27017`` as the port. Replace these values to point to
-your MongoDB instance.
+The next part of the connection string specifies the hostname or IP address of
+your MongoDB instance, followed by the port number. In the example above, we use
+``sample.host`` as the hostname and ``27017`` as the port. Replace these values
+to point to your MongoDB instance.
 
 The last part of the connection string contains connection and authentication
 options as parameters. In the example above, we set two connection options:
@@ -57,11 +57,26 @@ options, skip to the :ref:`node-connection-options` section.
 
 .. _connect-sample-node-driver:
 
-The code below shows how you can use a connection URI in a client to
-connect to MongoDB.
+Atlas Connection Example
+------------------------
 
-.. literalinclude:: /code-snippets/connection/connect.js
+You must create a client to connect to a MongoDB deployment on Atlas. To create
+a client, construct an instance of ``MongoClient``, passing in your 
+URI and a ``MongoClientOptions`` object.
+
+Use the ``serverApi`` option in your ``MongoClientOptions`` object to
+enable the {+stable-api+} feature, which forces the server to run operations
+with behavior compatible with the specified API version.
+
+The following code shows how you can specify the connection string and the
+{+stable-api+} client option when connecting to a MongoDB deployment on Atlas and
+verify that the connection is successful:
+
+.. literalinclude:: /code-snippets/connection/stable-api-connect.js
    :language: javascript
+
+To learn more about the Stable
+API feature, see the :ref:`{+stable-api+} page <nodejs-stable-api>`.
 
 .. _node-other-ways-to-connect:
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v4.11`:
 - [add stableapi connection example (#590)](https://github.com/mongodb/docs-node/pull/590)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)