### PR TITLE
[v5.1] DOCSP-27257 Add tip to avoid collScan on countDocuments (#611)

### DIFF
--- a/source/usage-examples/count.txt
+++ b/source/usage-examples/count.txt
@@ -33,14 +33,17 @@ accepts a :doc:`query </fundamentals/crud/query-document>` parameter.
 settings that affect the method's execution. Refer to the reference
 documentation for each method for more information.
 
-.. important::
+.. tip::
 
-   If you require an exact document count in your collection, use a query
-   to take advantage of the built-in index on the ``_id`` field.
+   You can improve performance when using ``countDocuments()`` to return the
+   total number of documents in a collection by avoiding a collection scan. To
+   do this, use a :manual:`hint </reference/method/cursor.hint>` to take
+   advantage of the built-in index on the ``_id`` field. Use this technique only
+   when calling ``countDocuments()`` with an empty query parameter.
 
-   .. code-block:: js
+   .. code-block:: javascript
 
-      myColl.countDocuments({ "_id": { "$exists": true } });
+      collection.countDocuments({}, { hint: "_id_" });
 
 Example
 -------


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v5.1`:
 - [DOCSP-27257 Add tip to avoid collScan on countDocuments (#611)](https://github.com/mongodb/docs-node/pull/611)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)