### PR TITLE
DOCSP-28958 Clarify Typescript Find and the _id section

### DIFF
--- a/source/fundamentals/typescript.txt
+++ b/source/fundamentals/typescript.txt
@@ -304,8 +304,8 @@ include the ``_id`` field in its schema, the driver infers that the type of the
 
    The type parameter passed to your ``Collection`` influences only the type
    inference of the fields returned from the method. The driver does not convert
-   the field to the specified type. The type of the fields in your type
-   parameter's schema should match the type of their corresponding fields in the
+   the field to the specified type. The type of each field in your type
+   parameter's schema should match the type of the corresponding field in the
    collection.
 
 The following code uses the :ref:`Pet <mongodb-node-typescript-pet-interface>`

--- a/source/fundamentals/typescript.txt
+++ b/source/fundamentals/typescript.txt
@@ -288,19 +288,28 @@ Find Methods and the _id Field
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``find`` and ``findOne`` methods of the ``Collection`` class include
-the ``_id`` field in their return type.
+the ``_id`` field in their return type. The driver infers the type of the
+returned ``_id`` field based on the type parameter you passed to your
+``Collection`` instance.
 
 If the type parameter you passed to your ``Collection`` instance includes the
-``_id`` field, the type of the ``_id`` field in the values returned from the 
-find methods is the same as the type of the ``_id``
-field in your type parameter.
+``_id`` field in its schema, the driver infers that the ``_id`` field returned
+from the method is of the type specified in the schema.
 
-If the type parameter you passed to your ``Collection`` instance does not include the ``_id``
-field, the driver gives the ``_id`` field in the values returned from the find methods
-the type ``ObjectId``.
+However, if the type parameter you passed to your ``Collection`` instance does not
+include the ``_id`` field in its schema, the driver infers that the type of the
+``_id`` field returned from the method is ``ObjectId``. 
 
-The following code uses the :ref:`Pet <mongodb-node-typescript-pet-interface>` interface to return
-a document with an ``_id`` of type ``ObjectId``:
+.. tip::
+
+   The type parameter passed to your ``Collection`` influences only the type
+   inference of the fields returned from the method. The driver does not convert
+   the field to the specified type. The type of the fields in your type
+   parameter's schema should match the type of their corresponding fields in the
+   collection.
+
+The following code uses the :ref:`Pet <mongodb-node-typescript-pet-interface>`
+interface to return a document with an ``_id`` inferred to be of type ``ObjectId``:
 
 .. code-block:: typescript
 
@@ -313,7 +322,7 @@ a document with an ``_id`` of type ``ObjectId``:
    const id : ObjectId = document._id;
 
 The following code uses the ``IdNumberPet`` interface to return a
-document with an ``_id`` field of type ``number``:
+document with an ``_id`` inferred to be of type ``number``:
 
 .. code-block:: typescript
 


### PR DESCRIPTION
# Pull Request Info

The original wording of the section made it seem like the driver converts the _id field based on the given schema. This PR clarifies what the section was intended to convey.

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-28958
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-28958-typescript-find-and-id/fundamentals/typescript/#find-methods-and-the-_id-field

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
