### PR TITLE
[v4.9] DOCSP-28958 Clarify Typescript Find and the _id section (#644)

### DIFF
--- a/source/fundamentals/typescript.txt
+++ b/source/fundamentals/typescript.txt
@@ -266,19 +266,28 @@ Find Methods and the _id Field
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``find`` and ``findOne`` methods of the ``Collection`` class include
-the ``_id`` field in their return type.
+the ``_id`` field in their return type. The driver infers the type of the
+returned ``_id`` field based on the type parameter you passed to your
+``Collection`` instance.
 
 If the type parameter you passed to your ``Collection`` instance includes the
-``_id`` field, the type of the ``_id`` field in the values returned from the 
-find methods is the same as the type of the ``_id``
-field in your type parameter.
+``_id`` field in its schema, the driver infers that the ``_id`` field returned
+from the method is of the type specified in the schema.
 
-If the type parameter you passed to your ``Collection`` instance does not include the ``_id``
-field, the driver gives the ``_id`` field in the values returned from the find methods
-the type ``ObjectId``.
+However, if the type parameter you passed to your ``Collection`` instance does not
+include the ``_id`` field in its schema, the driver infers that the type of the
+``_id`` field returned from the method is ``ObjectId``. 
 
-The following code uses the :ref:`Pet <mongodb-node-typescript-pet-interface>` interface to return
-a document with an ``_id`` of type ``ObjectId``:
+.. tip::
+
+   The type parameter passed to your ``Collection`` influences only the type
+   inference of the fields returned from the method. The driver does not convert
+   the field to the specified type. The type of each field in your type
+   parameter's schema should match the type of the corresponding field in the
+   collection.
+
+The following code uses the :ref:`Pet <mongodb-node-typescript-pet-interface>`
+interface to return a document with an ``_id`` inferred to be of type ``ObjectId``:
 
 .. code-block:: typescript
 
@@ -291,7 +300,7 @@ a document with an ``_id`` of type ``ObjectId``:
    const id : ObjectId = document._id;
 
 The following code uses the ``IdNumberPet`` interface to return a
-document with an ``_id`` field of type ``number``:
+document with an ``_id`` inferred to be of type ``number``:
 
 .. code-block:: typescript
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v4.9`:
 - [DOCSP-28958 Clarify Typescript Find and the _id section (#644)](https://github.com/mongodb/docs-node/pull/644)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)