### PR TITLE
DOCSP-29082: use sharedinclude in encrypt page

### DIFF
--- a/source/fundamentals/encrypt-fields.txt
+++ b/source/fundamentals/encrypt-fields.txt
@@ -1,71 +1,7 @@
+.. _node-fle:
+
 ==============
 Encrypt Fields
 ==============
 
-.. contents:: On this page
-   :local:
-   :backlinks: none
-   :depth: 2
-   :class: singlecol
-
-.. default-domain:: mongodb
-
-Overview
---------
-
-You can encrypt fields in a document using a set of features called
-**in-use encryption**.
-
-In-use encryption enables your client applications to encrypt data
-*before* sending it to MongoDB, and to query documents with encrypted fields.
-
-Because the driver encrypts the data before sending it to MongoDB, only
-your configured client applications can decrypt the data. Only applications
-using the driver with access to your encryption keys can access the decrypted,
-plaintext data. Should you have unauthorized access to your database, an
-attacker could only see the encrypted, ciphertext data.
-
-In-use encryption can help prevent exposure of the following sensitive types of data:
-
-- Credit card numbers
-- Addresses
-- Health information
-- Financial information
-- Any other sensitive or personally identifiable information (PII)
-
-MongoDB offers the following ways to encrypt fields:
-
-{+qe+}
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-{+qe+} is the next-generation in-use encryption feature,
-introduced in MongoDB 6.0 and available as a public preview. {+qe+}
-supports searching encrypted fields for equality and encrypts each value
-uniquely.
-
-The MongoDB manual contains detailed information on the following {+qe+} topics:
-
-- To get started, see the :ref:`{+qe+} Quick Start <qe-quick-start>`.
-- To learn how to use {+qe+}, see the :ref:`{+qe+} Fundamentals <qe-fundamentals>`.
-- To learn how to integrate your implementation with a KMS, see the :ref:`{+qe+} Tutorials <qe-tutorials>`.
-- To learn {+qe+} concepts, see the :ref:`{+qe+} Reference <qe-reference>`.
-
-{+csfle-long+}
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-{+csfle-long+} was introduced in MongoDB v4.2 and supports searching encrypted
-fields for equality. {+csfle-short+} differs from {+qe+} in that it requires
-that the encrypted fields you want to search must be determinstically encrypted.
-When you deterministically encrypt a value, the same input value produces
-the same output value. While deterministic encryption provides greater
-support for read operations, encrypted data with low :wikipedia:`cardinality <Cardinality>`
-is susceptible to recovery using :wikipedia:`frequency analysis <Frequency_analysis>`.
-
-The MongoDB manual contains detailed information on the following {+csfle-short+} topics:
-
-- To get started, see the :ref:`{+csfle-short+} Quick Start <csfle-quick-start>`.
-- To learn how to use {+csfle-short+}, see the :ref:`{+csfle-short+} Fundamentals <csfle-fundamentals>`.
-- To learn how to integrate your {+csfle-short+} implementation with a KMS, see the :ref:`{+csfle-short+} Tutorials <csfle-tutorials>`.
-- To learn {+csfle-short+} concepts, see the :ref:`{+csfle-short+} Reference <csfle-reference>`.
-
-
+.. sharedinclude:: dbx/encrypt-fields.rst


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - [DOCSP-29082](https://jira.mongodb.org/browse/DOCSP-29082)
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-29082-encrypt-include-link/fundamentals/encrypt-fields/

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Are all the links working?
