### PR TITLE
typo fixes surfaced by script

### DIFF
--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -59,7 +59,7 @@ pulling all matching documents into a collection in process memory.
 
    Because asynchronous calls directly modify the cursor, executing
    asynchronous calls on a single cursor simultaneously can also cause
-   undefined behaviour. Always wait for the previous
+   undefined behavior. Always wait for the previous
    asynchronous operation to complete before running another.
 
 .. note::

--- a/source/fundamentals/crud/read-operations/geo.txt
+++ b/source/fundamentals/crud/read-operations/geo.txt
@@ -70,7 +70,7 @@ Coordinates on a 2D Plane
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can also express geospatial queries using ``x`` and ``y`` coordinates in
-a two-dimentional Euclidian plane. Until MongoDB, this was the only format
+a two-dimensional Euclidean plane. Until MongoDB, this was the only format
 compatible with geospatial queries, and are now referred to as
 "legacy coordinate pairs".
 

--- a/source/fundamentals/crud/read-operations/retrieve.txt
+++ b/source/fundamentals/crud/read-operations/retrieve.txt
@@ -142,7 +142,7 @@ Watch / Subscribe
 You can use the ``watch()`` method to monitor a collection for changes to
 a collection that match certain criteria. These changes include inserted,
 updated, replaced, and deleted documents. You can pass this method
-a pipeline of aggregation comands that sequentially runs on the changed
+a pipeline of aggregation commands that sequentially runs on the changed
 data whenever write operations are executed on the collection.
 
 .. example::


### PR DESCRIPTION
Ran the alas_but_one.py script in this repo. 

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
