### PR TITLE
add redirect bc utf pg doesnt exist below v4.3

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -18,3 +18,4 @@ raw: ${prefix}/stable -> ${base}/current/
 [*-v5.0]: ${prefix}/${version}/quick-start/next-steps/ -> ${base}/${version}/quick-start/
 
 [v4.3-master]: ${prefix}/${version}/fundamentals/utf8-validation -> ${base}/${version}/fundamentals/bson/utf8-validation/
+[*-v4.3]: ${prefix}/${version}/fundamentals/utf8-validation -> ${base}/${version}/

--- a/config/redirects
+++ b/config/redirects
@@ -17,5 +17,5 @@ raw: ${prefix}/stable -> ${base}/current/
 [*-v5.0]: ${prefix}/${version}/quick-start/download-and-install/ -> ${base}/${version}/quick-start/
 [*-v5.0]: ${prefix}/${version}/quick-start/next-steps/ -> ${base}/${version}/quick-start/
 
-[v4.3-master]: ${prefix}/${version}/fundamentals/utf8-validation -> ${base}/${version}/fundamentals/bson/utf8-validation/
-[*-v4.2]: ${prefix}/${version}/fundamentals/utf8-validation -> ${base}/${version}/
+[v4.3-master]: ${prefix}/${version}/fundamentals/utf8-validation/ -> ${base}/${version}/fundamentals/bson/utf8-validation/
+[*-v4.2]: ${prefix}/${version}/fundamentals/utf8-validation/ -> ${base}/${version}/

--- a/config/redirects
+++ b/config/redirects
@@ -18,4 +18,4 @@ raw: ${prefix}/stable -> ${base}/current/
 [*-v5.0]: ${prefix}/${version}/quick-start/next-steps/ -> ${base}/${version}/quick-start/
 
 [v4.3-master]: ${prefix}/${version}/fundamentals/utf8-validation -> ${base}/${version}/fundamentals/bson/utf8-validation/
-[*-v4.3]: ${prefix}/${version}/fundamentals/utf8-validation -> ${base}/${version}/
+[*-v4.2]: ${prefix}/${version}/fundamentals/utf8-validation -> ${base}/${version}/


### PR DESCRIPTION
adding a redirect for versions below v4.3 because utf validation was introduced in v4.3


```
Redirect 301 /docs/drivers/node/v3.6/fundamentals/utf8-validation https://www.mongodb.com/docs/drivers/node/v3.6/
Redirect 301 /docs/drivers/node/v3.7/fundamentals/utf8-validation https://www.mongodb.com/docs/drivers/node/v3.7/
Redirect 301 /docs/drivers/node/v4.0/fundamentals/utf8-validation https://www.mongodb.com/docs/drivers/node/v4.0/
Redirect 301 /docs/drivers/node/v4.1/fundamentals/utf8-validation https://www.mongodb.com/docs/drivers/node/v4.1/
Redirect 301 /docs/drivers/node/v4.2/fundamentals/utf8-validation https://www.mongodb.com/docs/drivers/node/v4.2/
```