### PR TITLE
DOCSP-29805: no query criteria in find

### DIFF
--- a/source/fundamentals/crud/read-operations/retrieve.txt
+++ b/source/fundamentals/crud/read-operations/retrieve.txt
@@ -47,7 +47,7 @@ Find
 You can call the ``find()`` method on a ``Collection`` object. The
 method accepts a query document that describes the documents you want to
 retrieve. For more information on how to specify your query document,
-see our guide on how to :ref:`node-fundamentals-query-document`.
+see the :ref:`node-fundamentals-query-document` guide.
 
 .. tip:: No Query Criteria
    
@@ -64,11 +64,11 @@ see our guide on how to :ref:`node-fundamentals-query-document`.
       await myColl.find({}); // empty query
    
    If you don't pass a query or pass an empty query
-   to the ``findOne()`` method, the operation returns the first
-   document of a collection.
+   to the ``findOne()`` method, the operation returns a single
+   document from a collection.
 
-   Even if you pass an empty query in a find operation, you can
-   specify options. For example, the following code shows how you can
+   You can specify options in a find operation even when you pass an
+   empty query. For example, the following code shows how you can
    specify a projection as an option while executing a find operation
    with an empty query parameter:
 

--- a/source/fundamentals/crud/read-operations/retrieve.txt
+++ b/source/fundamentals/crud/read-operations/retrieve.txt
@@ -26,10 +26,10 @@ from the existing set of data, you can use a find operation such as the
 You can also further specify the information you are requesting by
 including additional parameters or by chaining other methods such as:
 
-- :doc:`Sort Results </fundamentals/crud/read-operations/sort>`
-- :doc:`Skip Returned Results </fundamentals/crud/read-operations/skip>`
-- :doc:`Limit the Number of Returned Results </fundamentals/crud/read-operations/limit>`
-- :doc:`Specify Which Fields to Return </fundamentals/crud/read-operations/project>`
+- :ref:`node-fundamentals-sort`
+- :ref:`node-fundamentals-skip`
+- :ref:`node-fundamentals-limit`
+- :ref:`node-fundamentals-project`
 
 You can also use an aggregation operation to retrieve data. This type of
 operation allows you to apply an ordered pipeline of transformations to the
@@ -47,7 +47,7 @@ Find
 You can call the ``find()`` method on a ``Collection`` object. The
 method accepts a query document that describes the documents you want to
 retrieve. For more information on how to specify your query document,
-see our guide on how to :doc:`Specify a Query </fundamentals/crud/query-document>`.
+see our guide on how to :ref:`node-fundamentals-query-document`.
 
 .. tip:: No Query Criteria
    
@@ -117,8 +117,8 @@ matching document or ``null`` if there are no matches.
         ...
       ]
 
-See the :doc:`find() </usage-examples/find>` and :doc:`findOne()
-</usage-examples/findOne>` for fully-runnable examples.
+See the :ref:`find() <node-usage-find>` and :ref:`findOne()
+<node-usage-findone>` for fully-runnable examples.
 
 Aggregate
 ---------
@@ -190,4 +190,4 @@ data whenever write operations are executed on the collection.
 
 
 For a runnable example of the ``watch()`` method using the NodeJS driver, see
-the :doc:`change streams </usage-examples/changeStream>` usage example.
+the :ref:`change streams <node-usage-watch>` usage example.

--- a/source/fundamentals/crud/read-operations/retrieve.txt
+++ b/source/fundamentals/crud/read-operations/retrieve.txt
@@ -49,10 +49,10 @@ method accepts a query document that describes the documents you want to
 retrieve. For more information on how to specify your query document,
 see our guide on how to :doc:`Specify a Query </fundamentals/crud/query-document>`.
 
-.. tip:: No Matching Criteria
+.. tip:: No Query Criteria
    
-   To execute a find operation that has no matching criteria, you can
-   pass an empty query or omit the query in your find
+   To execute a find operation that has no query criteria, you can
+   pass an empty query or omit the query document in your find
    method parameters.
 
    The following operations both return all documents in the
@@ -65,7 +65,7 @@ see our guide on how to :doc:`Specify a Query </fundamentals/crud/query-document
    
    If you don't pass a query or pass an empty query
    to the ``findOne()`` method, the operation returns the first
-   document in a collection.
+   document of a collection.
 
    Even if you pass an empty query in a find operation, you can
    specify options. For example, the following code shows how you can

--- a/source/fundamentals/crud/read-operations/retrieve.txt
+++ b/source/fundamentals/crud/read-operations/retrieve.txt
@@ -44,11 +44,41 @@ matching data is inserted.
 Find
 ----
 
-The ``find()`` method is called on the ``Collection`` object that
-references the collection you want to query. The method accepts a query
-document that describes the documents you want to retrieve. For more
-information on how to specify your query document, see our guide on
-how to :doc:`Specify a Query </fundamentals/crud/query-document>`.
+You can call the ``find()`` method on a ``Collection`` object. The
+method accepts a query document that describes the documents you want to
+retrieve. For more information on how to specify your query document,
+see our guide on how to :doc:`Specify a Query </fundamentals/crud/query-document>`.
+
+.. tip:: No Matching Criteria
+   
+   To execute a find operation that has no matching criteria, you can
+   pass an empty query or omit the query in your find
+   method parameters.
+
+   The following operations both return all documents in the
+   ``myColl`` collection:
+
+   .. code-block:: javascript
+
+      await myColl.find(); // no query
+      await myColl.find({}); // empty query
+   
+   If you don't pass a query or pass an empty query
+   to the ``findOne()`` method, the operation returns the first
+   document in a collection.
+
+   Even if you pass an empty query in a find operation, you can
+   specify options. For example, the following code shows how you can
+   specify a projection as an option while executing a find operation
+   with an empty query parameter:
+
+   .. code-block:: javascript
+
+      const options = {
+        projection: { _id: 0, field1: 1 },
+      };
+
+      const findResult = await myColl.findOne({}, options);
 
 If you resolve the ``Promise`` returned by ``find()``, you receive
 a reference to a ``Cursor`` with which you can navigate matched documents.
@@ -66,15 +96,14 @@ matching document or ``null`` if there are no matches.
       :start-after: start find crud example
       :end-before: end find crud example
 
-
    Once the operation returns, the ``findResult`` variable references a
    ``Cursor``. You can print the documents retrieved using the ``for await...of``
    syntax as shown below:
 
    .. code-block:: javascript
 
-      for await (const doc of cursor) {
-        console.dir(doc);
+      for await (const doc of findResult) {
+        console.log(doc);
       }
 
    The output might resemble the following:
@@ -111,15 +140,14 @@ group, and arrange the result data from a collection.
       :start-after: start aggregate crud example
       :end-before: end aggregate crud example
 
-
    Once the operation returns, the ``aggregateResult`` variable references a
    ``Cursor``. You can print the documents retrieved using the ``for await...of``
    syntax as shown below:
 
    .. code-block:: javascript
 
-      for await (const doc of cursor) {
-        console.dir(doc);
+      for await (const doc of aggregateResult) {
+        console.log(doc);
       }
 
    The output might resemble the following:


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - [DOCSP-29805](https://jira.mongodb.org/browse/DOCSP-29805)
[**Staging**](https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-29805-find-no-query/fundamentals/crud/read-operations/retrieve/#find)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
