### PR TITLE
DOCSP-29819: type regression issue fixed in 4.8.1

### DIFF
--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -372,6 +372,13 @@ To learn more, see `v4.9.0 Release Highlights <https://github.com/mongodb/node-m
 What's New in 4.8
 -----------------
 
+.. important:: Upgrade from v4.8.0 to v4.8.1
+
+   Version 4.8.1 includes a fix to a type regression issue that was
+   introduced in v4.8.0. By upgrading to v4.8.1, you can specify ``_id``
+   values and sub-documents when performing updates with the ``$set`` or
+   ``$setOnInsert`` operators.
+
 New features of the 4.8 {+driver-short+} release include:
 
 - Added auto-completion and type safety for nested keys in an update filter

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -374,10 +374,9 @@ What's New in 4.8
 
 .. important:: Upgrade from v4.8.0 to v4.8.1
 
-   Version 4.8.1 includes a fix to a type regression issue that was
-   introduced in v4.8.0. By upgrading to v4.8.1, you can specify ``_id``
-   values and sub-documents when performing updates with the ``$set`` or
-   ``$setOnInsert`` operators.
+   Version 4.8.1 fixes a type regression issue introduced in v4.8.0. By
+   upgrading to v4.8.1, you can specify ``_id`` values and sub-documents
+   when performing updates with the ``$set`` or ``$setOnInsert`` operators.
 
 New features of the 4.8 {+driver-short+} release include:
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - [DOCSP-29819](https://jira.mongodb.org/browse/DOCSP-29819)
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-29819-set-operator-issue-4.8/whats-new/#what-s-new-in-4.8

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
