### PR TITLE
DOCSP-30756: add list search indexes to cursor page

### DIFF
--- a/source/code-snippets/crud/cursor.js
+++ b/source/code-snippets/crud/cursor.js
@@ -60,16 +60,6 @@ async function rewind(myColl) {
   // end rewind cursor example
 }
 
-async function listIndexSearch(myColl){
-  // start listIndexSearch example
-  const cursor = myColl.listIndexSearch();
-  console.log("All the search indexes in the collection: ");
-  for await (const doc of cursor){
-    console.log(doc);
-  }
-  // end listIndexSearch example
-}
-
 async function close(myColl) {
   const cursor = myColl.find({});
 
@@ -90,7 +80,6 @@ async function run() {
     await fetchAll(orders);
     await rewind(orders);
     await count(orders);
-    //await listIndexSearch(orders);
   } finally {
     await client.close();
   }

--- a/source/code-snippets/crud/cursor.js
+++ b/source/code-snippets/crud/cursor.js
@@ -62,12 +62,11 @@ async function rewind(myColl) {
 
 async function listIndexSearch(myColl){
   // start listIndexSearch example
-  const allSearchIndexesCursor = myColl.listIndexSearch().toArray();
-  var indexes = "";
-  for (i in allSearchIndexesCursor){
-    indexes += i;
+  const cursor = myColl.listIndexSearch();
+  console.log("All the search indexes in the collection: ");
+  for await (const doc of cursor){
+    console.log(doc);
   }
-  console.log("All the search indexes in the collection: " + indexes);
   // end listIndexSearch example
 }
 

--- a/source/code-snippets/crud/cursor.js
+++ b/source/code-snippets/crud/cursor.js
@@ -60,6 +60,17 @@ async function rewind(myColl) {
   // end rewind cursor example
 }
 
+async function listIndexSearch(myColl){
+  // start listIndexSearch example
+  const allSearchIndexesCursor = myColl.listIndexSearch().toArray();
+  var indexes = "";
+  for (i in allSearchIndexesCursor){
+    indexes += i;
+  }
+  console.log("All the search indexes in the collection: " + indexes);
+  // end listIndexSearch example
+}
+
 async function close(myColl) {
   const cursor = myColl.find({});
 
@@ -80,6 +91,7 @@ async function run() {
     await fetchAll(orders);
     await rewind(orders);
     await count(orders);
+    //await listIndexSearch(orders);
   } finally {
     await client.close();
   }

--- a/source/code-snippets/indexes/listIndexes.js
+++ b/source/code-snippets/indexes/listIndexes.js
@@ -1,0 +1,27 @@
+const { MongoClient } = require("mongodb");
+
+// Replace the following with your MongoDB deployment's connection
+// string.
+const uri =
+  "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
+
+const client = new MongoClient(uri);
+
+import { MongoClient } from "mongodb";
+const database = client.db("<databaseName>");
+const collection = database.collection("<collectionName>");
+
+async function run() {
+  try {
+    // start listIndexes example
+    const result = await collection.listIndexes().toArray();
+    console.log("The indexes in the collection are: ");
+    for(const doc in result){
+    console.log(doc);
+    }
+    // end listIndexes example
+  } finally {
+    await client.close();
+  }
+}
+run().catch(console.dir);

--- a/source/code-snippets/indexes/listIndexes.js
+++ b/source/code-snippets/indexes/listIndexes.js
@@ -15,9 +15,9 @@ async function run() {
   try {
     // start listIndexes example
     const result = await collection.listIndexes().toArray();
-    console.log("The indexes in the collection are: ");
+    console.log("Existing indexes:\n");
     for(const doc in result){
-    console.log(doc);
+        console.log(doc);
     }
     // end listIndexes example
   } finally {

--- a/source/code-snippets/indexes/listSearchIndexes.js
+++ b/source/code-snippets/indexes/listSearchIndexes.js
@@ -15,9 +15,9 @@ async function run() {
   try {
     // start listSearchIndexes example
     const result = await collection.listSearchIndexes().toArray();
-    console.log("The search indexes in the collection are: ");
+    console.log("Existing search indexes:\n");
     for(const doc in result){
-    console.log(doc);
+        console.log(doc);
     }
     // end listSearchIndexes example
   } finally {

--- a/source/code-snippets/indexes/listSearchIndexes.js
+++ b/source/code-snippets/indexes/listSearchIndexes.js
@@ -1,0 +1,27 @@
+const { MongoClient } = require("mongodb");
+
+// Replace the following with your MongoDB deployment's connection
+// string.
+const uri =
+  "mongodb+srv://<user>:<password>@<cluster-url>?writeConcern=majority";
+
+const client = new MongoClient(uri);
+
+import { MongoClient } from "mongodb";
+const database = client.db("<databaseName>");
+const collection = database.collection("<collectionName>");
+
+async function run() {
+  try {
+    // start listSearchIndexes example
+    const result = await collection.listSearchIndexes().toArray();
+    console.log("The search indexes in the collection are: ");
+    for(const doc in result){
+    console.log(doc);
+    }
+    // end listSearchIndexes example
+  } finally {
+    await client.close();
+  }
+}
+run().catch(console.dir);

--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -114,6 +114,19 @@ through results rather than returning all documents at once.
    :start-after: start fetchAll cursor example
    :end-before: end fetchAll cursor example
 
+Return Search Indexes of Collection
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When using a v7.0 and later {+mbd-server+} cluster, you can use the new `listSearchIndex()
+<https://mongodb.github.io/node-mongodb-native/Next/classes/Collection.html#listSearchIndexes>`__
+to return a cursor with all the search indexes for the current
+collection. ``listSearchIndex()`` has an optional string parameter, ``name``, to
+return only the indexes with matching index names. It also has an
+optional ``aggregateOptions`` parameter. For more information, visit the
+`API Documentation 
+<https://mongodb.github.io/node-mongodb-native/Next/interfaces/AggregateOptions.html>'.
+ 
+
 Stream API
 ~~~~~~~~~~
 

--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -117,14 +117,14 @@ through results rather than returning all documents at once.
 Return Search Indexes of Collection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When using a v7.0 and later {+mbd-server+} cluster, you can use the new `listSearchIndex()
+When using a v7.0 and later {+mdb-server+} cluster, you can use the new `listSearchIndex()
 <https://mongodb.github.io/node-mongodb-native/Next/classes/Collection.html#listSearchIndexes>`__
 to return a cursor with all the search indexes for the current
 collection. ``listSearchIndex()`` has an optional string parameter, ``name``, to
 return only the indexes with matching index names. It also has an
 optional ``aggregateOptions`` parameter. For more information, visit the
 `API Documentation 
-<https://mongodb.github.io/node-mongodb-native/Next/interfaces/AggregateOptions.html>'. 
+<https://mongodb.github.io/node-mongodb-native/Next/interfaces/AggregateOptions.html>'__. 
  
 
 Stream API

--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -30,6 +30,8 @@ The following functions directly return cursors:
 
 - ``Collection.listIndexes()``
 
+- ``Collection.listSearchIndexes()``
+
 - ``Db.aggregate()``
 
 - ``Db.listCollections()``
@@ -113,25 +115,7 @@ through results rather than returning all documents at once.
    :language: javascript
    :start-after: start fetchAll cursor example
    :end-before: end fetchAll cursor example
-
-Return Search Indexes of Collection
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-When using a v7.0 and later {+mdb-server+} cluster, you can use the new `listSearchIndex()
-<https://mongodb.github.io/node-mongodb-native/Next/classes/Collection.html#listSearchIndexes>`__
-to return a cursor with all the search indexes for the current
-collection. ``listSearchIndex()`` has an optional string parameter, ``name``, to
-return only the indexes with matching index names. It also has an
-optional ``aggregateOptions`` parameter. For more information, visit the
-`API Documentation 
-<https://mongodb.github.io/node-mongodb-native/Next/interfaces/AggregateOptions.html>`__. 
-
-.. literalinclude:: /code-snippets/crud/cursor.js
-   :language: javascript
-   :start-after: start listIndexSearch example
-   :end-before: end listIndexSearch example
  
-
 Stream API
 ~~~~~~~~~~
 

--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -118,7 +118,7 @@ Return Search Indexes of Collection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When using a v7.0 and later {+mdb-server+} cluster, you can use the new `listSearchIndex()
-<https://mongodb.github.io/node-mongodb-native/Next/classes/Collection.html#listSearchIndexes>`
+<https://mongodb.github.io/node-mongodb-native/Next/classes/Collection.html#listSearchIndexes>`__
 to return a cursor with all the search indexes for the current
 collection. ``listSearchIndex()`` has an optional string parameter, ``name``, to
 return only the indexes with matching index names. It also has an

--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -125,6 +125,11 @@ return only the indexes with matching index names. It also has an
 optional ``aggregateOptions`` parameter. For more information, visit the
 `API Documentation 
 <https://mongodb.github.io/node-mongodb-native/Next/interfaces/AggregateOptions.html>`__. 
+
+.. literalinclude:: /code-snippets/crud/cursor.js
+   :language: javascript
+   :start-after: start listIndexSearch example
+   :end-before: end listIndexSearch example
  
 
 Stream API

--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -124,7 +124,7 @@ collection. ``listSearchIndex()`` has an optional string parameter, ``name``, to
 return only the indexes with matching index names. It also has an
 optional ``aggregateOptions`` parameter. For more information, visit the
 `API Documentation 
-<https://mongodb.github.io/node-mongodb-native/Next/interfaces/AggregateOptions.html>'.
+<https://mongodb.github.io/node-mongodb-native/Next/interfaces/AggregateOptions.html>'. 
  
 
 Stream API

--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -118,13 +118,13 @@ Return Search Indexes of Collection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When using a v7.0 and later {+mdb-server+} cluster, you can use the new `listSearchIndex()
-<https://mongodb.github.io/node-mongodb-native/Next/classes/Collection.html#listSearchIndexes>`__
+<https://mongodb.github.io/node-mongodb-native/Next/classes/Collection.html#listSearchIndexes>`
 to return a cursor with all the search indexes for the current
 collection. ``listSearchIndex()`` has an optional string parameter, ``name``, to
 return only the indexes with matching index names. It also has an
 optional ``aggregateOptions`` parameter. For more information, visit the
 `API Documentation 
-<https://mongodb.github.io/node-mongodb-native/Next/interfaces/AggregateOptions.html>'__. 
+<https://mongodb.github.io/node-mongodb-native/Next/interfaces/AggregateOptions.html>`__. 
  
 
 Stream API

--- a/source/fundamentals/indexes.txt
+++ b/source/fundamentals/indexes.txt
@@ -312,3 +312,42 @@ the following:
    E11000 duplicate key error index
 
 To learn more, see :manual:`Unique Indexes </core/index-unique>`.
+
+List Indexes
+~~~~~~~~~~~~
+
+The ``listIndexes()`` method allows you to list all the indexes'
+information in the collection. The ``listIndexes()`` method takes an
+optional parameter, `ListIndexesOptions
+<{+api+}/interfaces/ListIndexesOptions.html>`__, to set optional
+settings for the method. The ``listIndexes()`` method returns an
+object of type `ListIndexesCursor
+<{+api+}/classes/ListIndexesCursor.html>`__.
+
+The following example uses the ``listIndexes()`` method to list all the
+indexes' information in the collection.
+
+.. literalinclude:: /code-snippets/indexes/listIndexes.js
+   :language: javascript
+   :start-after: start listIndexes example
+   :end-before: end listIndexes example
+
+List Search Indexes
+~~~~~~~~~~~~~~~~~~~
+
+When connecting to {+mdb-server+} version 7.0 or later, you can use the new `listSearchIndexes()
+<https://mongodb.github.io/node-mongodb-native/Next/classes/Collection.html#listSearchIndexes>`__
+method to return a cursor that contains the search indexes for the current
+collection. The ``listSearchIndexes()`` method takes an optional string parameter, ``name``, to
+return only the indexes with matching index names. It also takes an
+optional `aggregateOptions
+<https://mongodb.github.io/node-mongodb-native/Next/interfaces/AggregateOptions.html>`__
+parameter.
+
+The following example uses the ``listSearchIndexes()` method to list all
+the search indexes in the collection.
+
+.. literalinclude:: /code-snippets/indexes/listSearchIndexes.js
+   :language: javascript
+   :start-after: start listSearchIndexes example
+   :end-before: end listSearchIndexes example

--- a/source/fundamentals/indexes.txt
+++ b/source/fundamentals/indexes.txt
@@ -314,21 +314,21 @@ the following:
 To learn more, see :manual:`Unique Indexes </core/index-unique>`.
 
 List Indexes
-~~~~~~~~~~~~
+------------
 
-The ``listIndexes()`` method allows you to list all the indexes'
-information in the collection. The ``listIndexes()`` method takes an
-optional parameter, `ListIndexesOptions
-<{+api+}/interfaces/ListIndexesOptions.html>`__, to set optional
-settings for the method. The ``listIndexes()`` method returns an
+You can use the ``listIndexes()`` method to list all of the indexes
+for a collection. The ``listIndexes()`` method takes an
+optional `ListIndexesOptions
+<{+api+}/interfaces/ListIndexesOptions.html>`__ parameter. The ``listIndexes()`` method returns an
 object of type `ListIndexesCursor
 <{+api+}/classes/ListIndexesCursor.html>`__.
 
 The following example uses the ``listIndexes()`` method to list all the
-indexes' information in the collection.
+indexes in a collection.
 
 .. literalinclude:: /code-snippets/indexes/listIndexes.js
    :language: javascript
+   :dedent:
    :start-after: start listIndexes example
    :end-before: end listIndexes example
 
@@ -337,7 +337,7 @@ List Search Indexes
 
 When connecting to {+mdb-server+} version 7.0 or later, you can use the new `listSearchIndexes()
 <https://mongodb.github.io/node-mongodb-native/Next/classes/Collection.html#listSearchIndexes>`__
-method to return a cursor that contains the search indexes for the current
+method to return a cursor that contains the search indexes of a given
 collection. The ``listSearchIndexes()`` method takes an optional string parameter, ``name``, to
 return only the indexes with matching index names. It also takes an
 optional `aggregateOptions

--- a/source/fundamentals/indexes.txt
+++ b/source/fundamentals/indexes.txt
@@ -317,14 +317,14 @@ List Indexes
 ------------
 
 You can use the ``listIndexes()`` method to list all of the indexes
-for a collection. The ``listIndexes()`` method takes an
+for a collection. The `listIndexes() <{+api+}/classes/Collection.html#listIndexes>`__ method takes an
 optional `ListIndexesOptions
 <{+api+}/interfaces/ListIndexesOptions.html>`__ parameter. The ``listIndexes()`` method returns an
 object of type `ListIndexesCursor
 <{+api+}/classes/ListIndexesCursor.html>`__.
 
-The following example uses the ``listIndexes()`` method to list all the
-indexes in a collection.
+The following code uses the ``listIndexes()`` method to list all the
+indexes in a collection:
 
 .. literalinclude:: /code-snippets/indexes/listIndexes.js
    :language: javascript
@@ -344,10 +344,11 @@ optional `aggregateOptions
 <https://mongodb.github.io/node-mongodb-native/Next/interfaces/AggregateOptions.html>`__
 parameter.
 
-The following example uses the ``listSearchIndexes()`` method to list all
-the search indexes in the collection.
+The following code uses the ``listSearchIndexes()`` method to list all
+the search indexes in the collection:
 
 .. literalinclude:: /code-snippets/indexes/listSearchIndexes.js
    :language: javascript
+   :dedent:
    :start-after: start listSearchIndexes example
    :end-before: end listSearchIndexes example

--- a/source/fundamentals/indexes.txt
+++ b/source/fundamentals/indexes.txt
@@ -344,7 +344,7 @@ optional `aggregateOptions
 <https://mongodb.github.io/node-mongodb-native/Next/interfaces/AggregateOptions.html>`__
 parameter.
 
-The following example uses the ``listSearchIndexes()` method to list all
+The following example uses the ``listSearchIndexes()`` method to list all
 the search indexes in the collection.
 
 .. literalinclude:: /code-snippets/indexes/listSearchIndexes.js


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-30756>
Staging - 
[Cursor page](https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-30756-add-listSearchIndexes-to-Cursor-pg/fundamentals/crud/read-operations/cursor/)
[Indexes](https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-30756-add-listSearchIndexes-to-Cursor-pg/fundamentals/indexes/)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Are all the links working?
