### PR TITLE
Docsp 30756 4.5 through 4.0 backport

### DIFF
--- a/source/fundamentals/indexes.txt
+++ b/source/fundamentals/indexes.txt
@@ -4,8 +4,6 @@
 Indexes
 =======
 
-.. default-domain:: mongodb
-
 .. contents:: On this page
    :local:
    :backlinks: none
@@ -149,6 +147,8 @@ query coverage, index bound computation, and sort behavior. For a full
 explanation of multikey indexes, including a discussion of their behavior
 and limitations, refer to the :manual:`Multikey Indexes page
 </core/index-multikey>` in the MongoDB Server manual.
+
+.. _node-fundamentals-text-indexes:
 
 Text Indexes
 ~~~~~~~~~~~~

--- a/source/fundamentals/indexes.txt
+++ b/source/fundamentals/indexes.txt
@@ -272,6 +272,19 @@ the following:
 Refer to the :manual:`Unique Indexes page </core/index-unique>` in the
 MongoDB server manual for more information.
 
+List Indexes
+------------
+
+You can use the ``listIndexes()`` method to list all of the indexes for
+a collection. The `listIndexes()
+<{+api+}/classes/Collection.html#listIndexes>`__ method takes an optional
+`ListIndexesOptions <{+api+}/interfaces/ListIndexesOptions.html>`__
+parameter. The ``listIndexes()`` method returns an object of type
+`ListIndexesCursor <{+api+}/classes/ListIndexesCursor.html>`__.
+
+The following code uses the ``listIndexes()`` method to list all the
+indexes in a collection:
+
 .. literalinclude:: /code-snippets/indexes/listIndexes.js
    :language: js
    :start-after: start-listIndexes-example

--- a/source/fundamentals/indexes.txt
+++ b/source/fundamentals/indexes.txt
@@ -285,19 +285,6 @@ parameter. The ``listIndexes()`` method returns an object of type
 The following code uses the ``listIndexes()`` method to list all the
 indexes in a collection:
 
-List Indexes
-------------
-
-You can use the ``listIndexes()`` method to list all of the indexes for
-a collection. The `listIndexes()
-<{+api+}/classes/Collection.html#listIndexes>`__ method takes an optional
-`ListIndexesOptions <{+api+}/interfaces/ListIndexesOptions.html>`__
-parameter. The ``listIndexes()`` method returns an object of type
-`ListIndexesCursor <{+api+}/classes/ListIndexesCursor.html>`__.
-
-The following code uses the ``listIndexes()`` method to list all the
-indexes in a collection:
-
 .. literalinclude:: /code-snippets/indexes/listIndexes.js
    :language: js
    :start-after: start-listIndexes-example

--- a/source/fundamentals/indexes.txt
+++ b/source/fundamentals/indexes.txt
@@ -285,6 +285,19 @@ parameter. The ``listIndexes()`` method returns an object of type
 The following code uses the ``listIndexes()`` method to list all the
 indexes in a collection:
 
+List Indexes
+------------
+
+You can use the ``listIndexes()`` method to list all of the indexes for
+a collection. The `listIndexes()
+<{+api+}/classes/Collection.html#listIndexes>`__ method takes an optional
+`ListIndexesOptions <{+api+}/interfaces/ListIndexesOptions.html>`__
+parameter. The ``listIndexes()`` method returns an object of type
+`ListIndexesCursor <{+api+}/classes/ListIndexesCursor.html>`__.
+
+The following code uses the ``listIndexes()`` method to list all the
+indexes in a collection:
+
 .. literalinclude:: /code-snippets/indexes/listIndexes.js
    :language: js
    :start-after: start-listIndexes-example

--- a/source/quick-start.txt
+++ b/source/quick-start.txt
@@ -4,8 +4,6 @@
 Quick Start
 ===========
 
-.. default-domain:: mongodb
-
 .. contents:: On this page
    :local:
    :backlinks: none
@@ -26,6 +24,8 @@ required) MongoDB instance with this guide.
 
 Follow the steps below to connect a sample Node.js application to a MongoDB
 instance on MongoDB Atlas.
+
+.. _node-quick-start-download-and-install:
 
 Set up Your Project
 -------------------


### PR DESCRIPTION
# Pull Request Info
While fixing the backport, I noticed there are errors in snooty when building from two targets not being found (see below) unrelated to my backport, so adding those as well.

ERROR(index.txt:30ish): Target not found: "label:node-quick-start-download-and-install"
ERROR(fundamentals/crud/read-operations/text.txt:59ish): Target not found: "label:node-fundamentals-text-indexes"

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-30756>

[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-30756-4.5-through-4.0-backport/fundamentals/indexes/#list-indexes-1)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Are all the links working?
