### PR TITLE
DOCSP-31156: remove mentions of j,wtimeout, and fsync

### DIFF
--- a/source/fundamentals/connection/connection-options.txt
+++ b/source/fundamentals/connection/connection-options.txt
@@ -73,7 +73,7 @@ parameters of the connection URI to specify the behavior of the client.
    * - **journal**
      - boolean
      - ``null``
-     - Specifies the default write concern ``"j"`` field for the client. See
+     - Specifies the journal write concern for the client. See
        :ref:`write concern <wc-j>` for more information.
 
    * - **loadBalanced**
@@ -279,7 +279,7 @@ parameters of the connection URI to specify the behavior of the client.
    * - **wTimeoutMS**
      - non-negative integer
      - ``null``
-     - Specifies the default write concern ``"wtimeout"`` field for the client.
+     - Specifies the default write concern timeout field for the client.
 
    * - **zlibCompressionLevel**
      - integer between ``-1`` and ``9`` (inclusive)


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

** most of the work for this ticket was completed when the what's new was revised for v5.7 in #707 
JIRA - <https://jira.mongodb.org/browse/DOCSP-31156>
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-31156-wc-options-deprecated/fundamentals/connection/connection-options/#std-label-node-connection-options

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Are all the links working?
