### PR TITLE
docsp-31720 - remove deprecated helpers

### DIFF
--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -51,6 +51,17 @@ planned upgrade version. For example, if you are upgrading the driver
 from v3.x to v5.x, address all breaking changes listed under v4.x and
 v5.x.
 
+.. _node-breaking-changes-v6.x:
+
+Version 6.x Breaking Changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- The driver removes support for the ``addUser()`` helper command. Use the
+  :manual:`createUser</reference/command/createUser>` command instead.
+- The driver removes support for the ``collStats`` helper command. Use the
+  :manual:`$collStats </reference/operator/aggregation/collStats>` aggregation operator
+  instead. 
+
 .. _node-breaking-changes-v5.x:
 
 Version 5.x Breaking Changes

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -57,8 +57,8 @@ Version 6.x Breaking Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - The driver removes support for the ``addUser()`` helper command. Use the
-  :manual:`createUser</reference/command/createUser>` command instead.
-- The driver removes support for the ``collStats`` helper command. Use the
+  :manual:`createUser </reference/command/createUser>` MongoDB Shell command instead.
+- The driver removes support for the ``collStats`` operation. Use the
   :manual:`$collStats </reference/operator/aggregation/collStats>` aggregation operator
   instead. 
 

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -12,6 +12,8 @@ What's New
 
 Learn what's new in:
 
+* :ref:`Version 6.0 <version-6.0>`
+* :ref:`Version 5.7 <version-5.7>`
 * :ref:`Version 5.7 <version-5.7>`
 * :ref:`Version 5.6 <version-5.6>`
 * :ref:`Version 5.5 <version-5.5>`
@@ -38,6 +40,19 @@ Learn what's new in:
 * :ref:`Version 4.0 <version-4.0>`
 * :ref:`Version 3.7 <version-3.7>`
 * :ref:`Version 3.6 <version-3.6>`
+
+.. _version-6.0:
+
+What's New in 6.0
+-----------------
+
+The {+driver-short+} v6.0 release includes the following features:
+
+- This release removes support for the ``addUser()`` helper command. Use the
+  :manual:`createUser</reference/command/createUser>` command instead.
+- This release removes support for the ``collStats`` helper command. Use the
+  :manual:`$collStats </reference/operator/aggregation/collStats>` aggregation operator
+  instead. 
 
 .. _version-5.7:
 

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -48,9 +48,9 @@ What's New in 6.0
 
 The {+driver-short+} v6.0 release includes the following features:
 
-- This release removes support for the ``addUser()`` helper command. Use the
-  :manual:`createUser</reference/command/createUser>` command instead.
-- This release removes support for the ``collStats`` helper command. Use the
+- Removes support for the ``addUser()`` helper command. Use the
+  :manual:`createUser </reference/command/createUser>` MongoDB Shell command instead.
+- Removes support for the ``collStats`` operation. Use the
   :manual:`$collStats </reference/operator/aggregation/collStats>` aggregation operator
   instead. 
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-31720
Staging:
- [What's New](https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/docsp-31720-remove-methods/whats-new/#what-s-new-in-6.0)
- [Upgrade](https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/docsp-31720-remove-methods/upgrade/#version-6.x-breaking-changes)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Are all the links working?
