### PR TITLE
reword admonition

### DIFF
--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -139,7 +139,7 @@ New features of the 5.4 {+driver-short+} release include:
 
 .. important:: Deprecation Notice
 
-  - The ``collStats`` helper command is deprecated. Use the :manual:`$collStats
+  - The ``collStats`` operation is deprecated. Use the :manual:`$collStats
     </reference/operator/aggregation/collStats>` aggregation operator instead.
   - The TypeScript interface passed to the ``db.command()`` method incorrectly
     includes certain options. These options have been deprecated.


### PR DESCRIPTION
# Pull Request Info

Reworded admonition in 5.4 per Chris's comment from [this PR.](https://github.com/mongodb/docs-node/pull/729). Will be backported back through 5.4

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

Staging - <https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/NNNNN/>

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
