### PR TITLE
DOCSP-31290: ssl options deprecated in v6.0

### DIFF
--- a/source/fundamentals/authentication/mechanisms.txt
+++ b/source/fundamentals/authentication/mechanisms.txt
@@ -283,8 +283,8 @@ Pass the location of your client certificate file as the value of
 
 .. tip::
    
-   To learn more about enabling TLS on a connection, see the
-   :ref:`fundamentals page <node-connect-tls>`.
+   To learn more about enabling TLS on a connection, see
+   :ref:`node-connect-tls`.
 
 TLS Options
 ~~~~~~~~~~~

--- a/source/fundamentals/authentication/mechanisms.txt
+++ b/source/fundamentals/authentication/mechanisms.txt
@@ -281,11 +281,16 @@ Pass the location of your client certificate file as the value of
 .. literalinclude:: /code-snippets/authentication/x509.js
    :language: javascript
 
-TLS/SSL Options
-~~~~~~~~~~~~~~~
+.. tip::
+   
+   To learn more about enabling TLS on a connection, see the
+   :ref:`fundamentals page <node-connect-tls>`.
 
-The following table describes each of the TLS/SSL options that can be passed
-as a parameter in the connection URI.
+TLS Options
+~~~~~~~~~~~
+
+The following table describes the TLS options that you can set in a
+connection URI.
 
 .. list-table::
    :widths: 35 12 10 43
@@ -299,7 +304,7 @@ as a parameter in the connection URI.
    * - ``tls``
      - boolean
      - ``false``
-     - Specifies whether to use TLS/SSL connections.
+     - Specifies whether to enable TLS on the connection.
 
    * - ``tlsInsecure``
      - boolean

--- a/source/fundamentals/connection/tls.txt
+++ b/source/fundamentals/connection/tls.txt
@@ -189,10 +189,10 @@ You can include the filepaths for your certificates as client options to
 retrieve your certificates while connecting with TLS.
 
 The following code shows how to provide certificate filepaths as options
-in your ``MongoClient``: 
+in your ``MongoClient``:
 
 .. code-block:: js
-   :emphasize-lines: 4-6
+   :emphasize-lines: 4-5
    
    // Pass filepaths as client options
    const client = new MongoClient(uri, {

--- a/source/fundamentals/connection/tls.txt
+++ b/source/fundamentals/connection/tls.txt
@@ -198,7 +198,6 @@ in your ``MongoClient``:
    const client = new MongoClient(uri, {
      tls: true,
      tlsCAFile: `<path to CA certificate>`,
-     tlsCertificateFile: `<path to public client certificate>`,
      tlsCertificateKeyFile: `<path to private client key>`,
    });
 

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -55,7 +55,7 @@ The {+driver-short+} v6.0 release includes the following features:
    is deprecated.
 
    Instead, you should store your certificates in a ``SecureContext``
-   object or using the ``tls`` prefixed options in a
+   object or set the ``tls`` prefixed options in your
    ``MongoClientOptions`` instance. To learn more, see :ref:`node-connect-tls`.
 
 - Removes support for the ``addUser()`` helper command. Use the

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -50,12 +50,12 @@ The {+driver-short+} v6.0 release includes the following features:
 
 .. important:: Deprecation Notice
    
-   All of the ``ssl`` prefixed options in the ``MongoClientOptions``
+   All of the ``ssl``-prefixed options in the ``MongoClientOptions``
    type are deprecated. In addition, the ``tlsCertificateFile`` option
    is deprecated.
 
    Instead, you should store your certificates in a ``SecureContext``
-   object or set the ``tls`` prefixed options in your
+   object or set the ``tls``-prefixed options in your
    ``MongoClientOptions`` instance. To learn more, see :ref:`node-connect-tls`.
 
 - Removes support for the ``addUser()`` helper command. Use the

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -48,11 +48,21 @@ What's New in 6.0
 
 The {+driver-short+} v6.0 release includes the following features:
 
+.. important:: Deprecation Notice
+   
+   All of the ``ssl`` prefixed options in the ``MongoClientOptions``
+   type are deprecated. In addition, the ``tlsCertificateFile`` option
+   is deprecated.
+
+   Instead, you should store your certificates in a ``SecureContext``
+   object or using the ``tls`` prefixed options in a
+   ``MongoClientOptions`` instance. To learn more, see :ref:`node-connect-tls`.
+
 - Removes support for the ``addUser()`` helper command. Use the
   :manual:`createUser </reference/command/createUser>` MongoDB Shell command instead.
 - Removes support for the ``collStats`` operation. Use the
   :manual:`$collStats </reference/operator/aggregation/collStats>` aggregation operator
-  instead. 
+  instead.
 
 .. _version-5.7:
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-31290>
Staging:
- [What's New](https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-31290-ssl-deprecation/whats-new/#what-s-new-in-6.0)
- [TLS page section](https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-31290-ssl-deprecation/fundamentals/connection/tls/#provide-certificate-filepaths)
- [auth page](https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-31290-ssl-deprecation/fundamentals/authentication/mechanisms/#tls-options)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
