### PR TITLE
DOCSP-31377: connection pool created event options v6

### DIFF
--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -61,7 +61,11 @@ Version 6.x Breaking Changes
   :manual:`createUser </reference/command/createUser>` MongoDB Shell command instead.
 - The driver removes support for the ``collStats`` operation. Use the
   :manual:`$collStats </reference/operator/aggregation/collStats>` aggregation operator
-  instead. 
+  instead.
+- The driver deprecates all of the ``ssl``-prefixed options and the
+  ``tlsCertificateFile`` option in the ``MongoClientOptions`` type.
+  Create a ``SecureContext`` object or set the ``tls``-prefixed options
+  in your ``MongoClientOptions`` instance instead.
 
 .. _node-breaking-changes-v5.x:
 

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -64,9 +64,20 @@ The {+driver-short+} v6.0 release includes the following features:
 
 - Removes support for the ``addUser()`` helper command. Use the
   :manual:`createUser </reference/command/createUser>` MongoDB Shell command instead.
+
 - Removes support for the ``collStats`` operation. Use the
   :manual:`$collStats </reference/operator/aggregation/collStats>` aggregation operator
   instead.
+
+- The ``options`` field of the ``ConnectionPoolCreatedEvent`` type
+  contains only the following fields, which are the non-default pool
+  options:
+
+  - ``maxConnecting``
+  - ``maxPoolSize``
+  - ``minPoolSize``
+  - ``maxIdleTimeMS``
+  - ``waitQueueTimeoutMS``
 
 .. _version-5.7:
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-31377>
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-31377-connection-pool-event-fields/whats-new/#what-s-new-in-6.0

**I also added something to the upgrade guide that I forgot to include in #731** - [staging](https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-31377-connection-pool-event-fields/upgrade/#version-6.x-breaking-changes)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
