### PR TITLE
DOCSP-31483: tls cert files read async v6

### DIFF
--- a/source/fundamentals/connection/connection-options.txt
+++ b/source/fundamentals/connection/connection-options.txt
@@ -226,53 +226,53 @@ parameters of the connection URI to specify the behavior of the client.
      - ``false``
      - Specifies whether TLS is required for connections to the server.
        Using a ``srvServiceName`` of  ``"mongodb+srv"``, or specifying other
-       ``tls`` prefixed options will default ``tls`` to ``true``. To
-       learn more about this connection option, see
-       :ref:`node-connect-tls`.
+       ``tls``-prefixed options implicitly sets the value of ``tls`` to
+       ``true``.
 
    * - **tlsAllowInvalidCertificates**
      - boolean
      - ``false``
      - Specifies whether the driver should error when the server’s
-       TLS certificate is invalid. To learn more about this connection
-       option, see :ref:`node-connect-tls`.
+       TLS certificate is invalid. You should only set this option to
+       ``true`` for testing purposes.
 
    * - **tlsAllowInvalidHostnames**
      - boolean
      - ``false``
      - Specifies whether the driver should error when there is a mismatch
        between the server’s hostname and the hostname specified by the
-       TLS certificate. To learn more about this connection option, see
-       :ref:`node-connect-tls`.
+       TLS certificate. You should only set this option to
+       ``true`` for testing purposes.
 
    * - **tlsCAFile**
      - string
      - ``null``
      - Specifies the path to a file with either a single or bundle of certificate
        authorities to trust when making a TLS connection. To learn more
-       about this connection option, see :ref:`node-connect-tls`.
+       about setting this connection option, see the :ref:`Provide
+       Certificate Filepaths <node-tls-filepaths>` section of the TLS guide.
 
    * - **tlsCertificateKeyFile**
      - string
      - ``null``
      - Specifies the path to the client certificate file or the client
        private key file. If you need both, you must concatenate the
-       files. To learn more about this connection option, see
-       :ref:`node-connect-tls`.
+       files. To learn more about setting this connection option, see
+       the :ref:`Provide Certificate Filepaths <node-tls-filepaths>`
+       section of the TLS guide.
 
    * - **tlsCertificateKeyFilePassword**
      - string
      - ``null``
      - Specifies the password to decrypt the client private key to be used
-       for TLS connections. To learn more about this connection option,
-       see :ref:`node-connect-tls`.
+       for TLS connections.
 
    * - **tlsInsecure**
      - boolean
      - ``false``
      - Specifies to relax TLS constraints as much as possible, such as
-       allowing invalid certificates or hostname mismatches. To learn
-       more about this connection option, see :ref:`node-connect-tls`.
+       allowing invalid certificates or hostname mismatches. You should
+       only set this option to ``true`` for testing purposes.
 
    * - **w**
      - non-negative integer or string

--- a/source/fundamentals/connection/connection-options.txt
+++ b/source/fundamentals/connection/connection-options.txt
@@ -226,44 +226,53 @@ parameters of the connection URI to specify the behavior of the client.
      - ``false``
      - Specifies whether TLS is required for connections to the server.
        Using a ``srvServiceName`` of  ``"mongodb+srv"``, or specifying other
-       ``tls`` prefixed options will default ``tls`` to ``true``.
+       ``tls`` prefixed options will default ``tls`` to ``true``. To
+       learn more about this connection option, see
+       :ref:`node-connect-tls`.
 
    * - **tlsAllowInvalidCertificates**
      - boolean
      - ``false``
      - Specifies whether the driver should error when the server’s
-       TLS certificate is invalid.
+       TLS certificate is invalid. To learn more about this connection
+       option, see :ref:`node-connect-tls`.
 
    * - **tlsAllowInvalidHostnames**
      - boolean
      - ``false``
      - Specifies whether the driver should error when there is a mismatch
        between the server’s hostname and the hostname specified by the
-       TLS certificate.
+       TLS certificate. To learn more about this connection option, see
+       :ref:`node-connect-tls`.
 
    * - **tlsCAFile**
      - string
      - ``null``
      - Specifies the path to a file with either a single or bundle of certificate
-       authorities to trust when making a TLS connection.
+       authorities to trust when making a TLS connection. To learn more
+       about this connection option, see :ref:`node-connect-tls`.
 
    * - **tlsCertificateKeyFile**
      - string
      - ``null``
      - Specifies the path to the client certificate file or the client
-       private key file. If you need both, you must concatenate the files.
+       private key file. If you need both, you must concatenate the
+       files. To learn more about this connection option, see
+       :ref:`node-connect-tls`.
 
    * - **tlsCertificateKeyFilePassword**
      - string
      - ``null``
      - Specifies the password to decrypt the client private key to be used
-       for TLS connections.
+       for TLS connections. To learn more about this connection option,
+       see :ref:`node-connect-tls`.
 
    * - **tlsInsecure**
      - boolean
      - ``false``
      - Specifies to relax TLS constraints as much as possible, such as
-       allowing invalid certificates or hostname mismatches.
+       allowing invalid certificates or hostname mismatches. To learn
+       more about this connection option, see :ref:`node-connect-tls`.
 
    * - **w**
      - non-negative integer or string

--- a/source/fundamentals/connection/tls.txt
+++ b/source/fundamentals/connection/tls.txt
@@ -182,12 +182,14 @@ To learn more about the ``createSecureContext()`` method and the
 For a runnable example that uses a ``SecureContext`` object, see
 the :ref:`SecureContext Example <node-securecontext-full-example>`.
 
+.. _node-tls-filepaths:
+
 Provide Certificate Filepaths
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can include the filepaths for your certificates as client options to
 retrieve your certificates while connecting with TLS. The driver reads
-these files when you first call the ``connect()`` method on your
+these files when you call the ``connect()`` method on your
 ``MongoClient`` instance.
 
 The following code shows how to provide certificate filepaths as options

--- a/source/fundamentals/connection/tls.txt
+++ b/source/fundamentals/connection/tls.txt
@@ -186,7 +186,9 @@ Provide Certificate Filepaths
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can include the filepaths for your certificates as client options to
-retrieve your certificates while connecting with TLS.
+retrieve your certificates while connecting with TLS. The driver reads
+these files when you first call the ``connect()`` method on your
+``MongoClient`` instance.
 
 The following code shows how to provide certificate filepaths as options
 in your ``MongoClient``:

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -67,7 +67,7 @@ Version 6.x Breaking Changes
   Create a ``SecureContext`` object or set the ``tls``-prefixed options
   in your ``MongoClientOptions`` instance instead.
 - The driver reads files set in the ``tlsCAFile`` and
-  ``tlsCertificateKeyFile`` connection options when you first call the
+  ``tlsCertificateKeyFile`` connection options when you call the
   ``MongoClient.connect()`` method, not when you create the
   ``MongoClient`` instance.
 

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -66,6 +66,10 @@ Version 6.x Breaking Changes
   ``tlsCertificateFile`` option in the ``MongoClientOptions`` type.
   Create a ``SecureContext`` object or set the ``tls``-prefixed options
   in your ``MongoClientOptions`` instance instead.
+- The driver reads files set in the ``tlsCAFile`` and
+  ``tlsCertificateKeyFile`` connection options when you first call the
+  ``MongoClient.connect()`` method, not when you create the
+  ``MongoClient`` instance.
 
 .. _node-breaking-changes-v5.x:
 

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -79,6 +79,11 @@ The {+driver-short+} v6.0 release includes the following features:
   - ``maxIdleTimeMS``
   - ``waitQueueTimeoutMS``
 
+- The driver asynchronously reads files set in the ``tlsCAFile`` and
+  ``tlsCertificateKeyFile`` connection options when you first call
+  the ``MongoClient.connect()`` method, instead of when you create a
+  ``MongoClient`` instance.
+
 .. _version-5.7:
 
 What's New in 5.7

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -80,8 +80,8 @@ The {+driver-short+} v6.0 release includes the following features:
   - ``waitQueueTimeoutMS``
 
 - The driver asynchronously reads files set in the ``tlsCAFile`` and
-  ``tlsCertificateKeyFile`` connection options when you first call
-  the ``MongoClient.connect()`` method, instead of when you create a
+  ``tlsCertificateKeyFile`` connection options when you call
+  the ``MongoClient.connect()`` method, not when you create a
   ``MongoClient`` instance.
 
 .. _version-5.7:


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-31483>
Staging:
- [whats new](https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-31483-cert-files-read-async/whats-new/#what-s-new-in-6.0)
- [upgrade](https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-31483-cert-files-read-async/upgrade/#version-6.x-breaking-changes)
- [TLS](https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-31483-cert-files-read-async/fundamentals/connection/tls/#provide-certificate-filepaths)
- [connection options](https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-31483-cert-files-read-async/fundamentals/connection/connection-options/#:~:text=of%20an%20operation.-,tls,-boolean)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
