### PR TITLE
DOCSP-31924 mongodb-client-encryption changes for 6.0

### DIFF
--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -71,7 +71,7 @@ Version 6.x Breaking Changes
   ``MongoClient.connect()`` method, not when you create the
   ``MongoClient`` instance.
 - If you add ``mongodb-client-encryption`` as a dependency,
-  the major version number must match that of the {+driver-short}. For example,
+  the major version number must match that of the {+driver-short+}. For example,
   {+driver-short+} v6.x.x requires ``mongodb-client-encryption`` v6.x.x.
 - Automatic Encryption methods are now in the {+driver-short+}. You must
   import these methods from the driver instead of from

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -70,6 +70,12 @@ Version 6.x Breaking Changes
   ``tlsCertificateKeyFile`` connection options when you call the
   ``MongoClient.connect()`` method, not when you create the
   ``MongoClient`` instance.
+- The major version number of ``mongodb-client-encryption`` must now be the
+  same as the major version number of the {+driver-short+}. For example,
+  {+driver v6.x.x requires ``mongodb-client-encryption`` v6.x.x.
+- Automatic Encryption methods are now in the {+driver-short+}. You must now
+  import these methods from the driver rather than from
+  ``mongodb-client-encryption``.
 
 .. _node-breaking-changes-v5.x:
 

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -70,11 +70,11 @@ Version 6.x Breaking Changes
   ``tlsCertificateKeyFile`` connection options when you call the
   ``MongoClient.connect()`` method, not when you create the
   ``MongoClient`` instance.
-- The major version number of ``mongodb-client-encryption`` must now be the
-  same as the major version number of the {+driver-short+}. For example,
+- If you add ``mongodb-client-encryption`` as a dependency,
+  the major version number must match that of the {+driver-short}. For example,
   {+driver-short+} v6.x.x requires ``mongodb-client-encryption`` v6.x.x.
-- Automatic Encryption methods are now in the {+driver-short+}. You must now
-  import these methods from the driver rather than from
+- Automatic Encryption methods are now in the {+driver-short+}. You must
+  import these methods from the driver instead of from
   ``mongodb-client-encryption``.
 
 .. _node-breaking-changes-v5.x:

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -72,7 +72,7 @@ Version 6.x Breaking Changes
   ``MongoClient`` instance.
 - The major version number of ``mongodb-client-encryption`` must now be the
   same as the major version number of the {+driver-short+}. For example,
-  {+driver v6.x.x requires ``mongodb-client-encryption`` v6.x.x.
+  {+driver-short+} v6.x.x requires ``mongodb-client-encryption`` v6.x.x.
 - Automatic Encryption methods are now in the {+driver-short+}. You must now
   import these methods from the driver rather than from
   ``mongodb-client-encryption``.

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -52,10 +52,10 @@ What's New in 6.0
    
    - The major version number of ``mongodb-client-encryption`` must now be the
      same as the major version number of the {+driver-short+}. For example,
-     {+driver-short+} v6.x.x requires ``mongodb-client-encryption`` v6.x.x.
+     {+driver v6.x.x requires ``mongodb-client-encryption`` v6.x.x.
    
-   - Automatic Encryption methods have been moved to the driver. You must now
-     import these methods from the {+driver-short+} rather than from
+   - Automatic Encryption methods are now in the {+driver-short+}. You must now
+     import these methods from the driver rather than from
      ``mongodb-client-encryption``.
 
 The {+driver-short+} v6.0 release includes the following features:

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -52,7 +52,7 @@ What's New in 6.0
    
    - The major version number of ``mongodb-client-encryption`` must now be the
      same as the major version number of the {+driver-short+}. For example,
-     {+driver v6.x.x requires ``mongodb-client-encryption`` v6.x.x.
+     {+driver-short+} v6.x.x requires ``mongodb-client-encryption`` v6.x.x.
    
    - Automatic Encryption methods are now in the {+driver-short+}. You must now
      import these methods from the driver rather than from

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -51,7 +51,7 @@ What's New in 6.0
    - Version 6.0 of the {+driver-short+} requires Node.js v16.20.1 or later.
    
    - If you add ``mongodb-client-encryption`` as a dependency,
-     the major version number must match that of the {+driver-short}. For example,
+     the major version number must match that of the {+driver-short+}. For example,
      {+driver-short+} v6.x.x requires ``mongodb-client-encryption`` v6.x.x.
    
    - Automatic Encryption methods are now in the {+driver-short+}. You must

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -50,12 +50,12 @@ What's New in 6.0
 
    - Version 6.0 of the {+driver-short+} requires Node.js v16.20.1 or later.
    
-   - The major version number of ``mongodb-client-encryption`` must now be the
-     same as the major version number of the {+driver-short+}. For example,
+   - If you add ``mongodb-client-encryption`` as a dependency,
+     the major version number must match that of the {+driver-short}. For example,
      {+driver-short+} v6.x.x requires ``mongodb-client-encryption`` v6.x.x.
    
-   - Automatic Encryption methods are now in the {+driver-short+}. You must now
-     import these methods from the driver rather than from
+   - Automatic Encryption methods are now in the {+driver-short+}. You must
+     import these methods from the driver instead of from
      ``mongodb-client-encryption``.
 
 The {+driver-short+} v6.0 release includes the following features:

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -48,7 +48,15 @@ What's New in 6.0
 
 .. important:: Breaking Changes in v6.0
 
-   Version 6.0 of the {+driver-short+} requires Node.js v16.20.1 or later.
+   - Version 6.0 of the {+driver-short+} requires Node.js v16.20.1 or later.
+   
+   - The major version number of ``mongodb-client-encryption`` must now be the
+     same as the major version number of the {+driver-short+}. For example,
+     {+driver-short+} v6.x.x requires ``mongodb-client-encryption`` v6.x.x.
+   
+   - Automatic Encryption methods have been moved to the driver. You must now
+     import these methods from the {+driver-short+} rather than from
+     ``mongodb-client-encryption``.
 
 The {+driver-short+} v6.0 release includes the following features:
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-31924
Staging -
[What's New ](https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-31924-move-clientEncryption/whats-new/#std-label-version-6.0)
[Upgrade](https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-31924-move-clientEncryption/upgrade/)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
