### PR TITLE
DOCSP-31807: includeResultMetadata option behavior changes for findOneAnd... methods

### DIFF
--- a/source/fundamentals/crud/compound-operations.txt
+++ b/source/fundamentals/crud/compound-operations.txt
@@ -48,10 +48,14 @@ configurable :ref:`sort <node-fundamentals-sort>` and
 
    Starting in version 5.7, you can set the ``includeResultMetadata``
    setting in the ``options`` object to specify the return type for each
-   of these methods. The setting defaults to ``true``, which means the
-   method returns a ``ModifyResult`` type. If you set
-   ``includeResultMetadata`` to ``false``, the method returns the
-   modified document.
+   of these methods.
+   
+   Starting in version 6.0, the setting defaults to
+   ``false``, which means each method returns either the matched document
+   or ``null`` if no document is matched. If you set
+   ``includeResultMetadata`` to ``true``, the method returns a
+   ``ModifyResult`` type that contains the found document and additional
+   metadata.
 
    Suppose a collection contains the following document:
 
@@ -60,13 +64,12 @@ configurable :ref:`sort <node-fundamentals-sort>` and
       { _id: 1, x: "on" }
 
    The following code shows the return type for ``findOneAndDelete()``
-   operations when ``includeResultMetadata`` is set to ``true`` and
-   ``false``:
+   operations depending on the value of the ``includeResultMetadata`` option:
 
    .. code-block:: js
 
-      // returns { _id: 1, x: 'on' }
-      await coll.findOneAndDelete({ x: "on" }, { includeResultMetadata: false });
+      // default, returns { _id: 1, x: 'on' }
+      await coll.findOneAndDelete({ x: "on" });
 
       // returns { lastErrorObject: { n: 1 }, value: { _id: 1, x: 'on' }, ok: 1, ... }
       await coll.findOneAndDelete({ x: "on" }, { includeResultMetadata: true });

--- a/source/fundamentals/crud/compound-operations.txt
+++ b/source/fundamentals/crud/compound-operations.txt
@@ -50,12 +50,11 @@ configurable :ref:`sort <node-fundamentals-sort>` and
    setting in the ``options`` object to specify the return type for each
    of these methods.
    
-   Starting in version 6.0, the setting defaults to
-   ``false``, which means each method returns either the matched document
-   or ``null`` if no document is matched. If you set
-   ``includeResultMetadata`` to ``true``, the method returns a
-   ``ModifyResult`` type that contains the found document and additional
-   metadata.
+   Starting in version 6.0, this setting defaults to ``false``, which
+   means each method returns either the matched document or ``null`` if no
+   document is found. If you set ``includeResultMetadata`` to
+   ``true``, the method returns a ``ModifyResult`` type that contains
+   the found document and additional metadata.
 
    Suppose a collection contains the following document:
 
@@ -63,18 +62,21 @@ configurable :ref:`sort <node-fundamentals-sort>` and
 
       { _id: 1, x: "on" }
 
-   The following code shows the return type for ``findOneAndDelete()``
-   operations depending on the value of the ``includeResultMetadata`` option:
+   The following code shows how the value of the
+   ``includeResultMetadata`` option changes the return type of
+   the ``findOneAndDelete()`` method:
 
    .. code-block:: js
 
-      // default, returns { _id: 1, x: 'on' }
+      // default behavior
+      // returns { _id: 1, x: 'on' }
       await coll.findOneAndDelete({ x: "on" });
 
       // returns { lastErrorObject: { n: 1 }, value: { _id: 1, x: 'on' }, ok: 1, ... }
       await coll.findOneAndDelete({ x: "on" }, { includeResultMetadata: true });
 
-      // no document matched, returns null
+      // no document matched
+      // returns null
       await coll.findOneAndDelete({ x: "off" }, { includeResultMetadata: false });
 
 You can set the ``returnDocument`` setting in the ``options`` object for the

--- a/source/fundamentals/crud/compound-operations.txt
+++ b/source/fundamentals/crud/compound-operations.txt
@@ -51,12 +51,13 @@ configurable :ref:`sort <node-fundamentals-sort>` and
    of these methods.
    
    Starting in version 6.0, this setting defaults to ``false``, which
-   means each method returns either the matched document or ``null`` if no
-   document is found. If you set ``includeResultMetadata`` to
-   ``true``, the method returns a ``ModifyResult`` type that contains
-   the found document and additional metadata.
+   means that each method returns either the matched document or
+   ``null`` if no document is found. If you set
+   ``includeResultMetadata`` to ``true``, the method returns a
+   ``ModifyResult`` type that contains the found document and additional
+   metadata.
 
-   Suppose a collection contains the following document:
+   Suppose a collection contains only the following document:
 
    .. code-block:: json
 
@@ -77,7 +78,7 @@ configurable :ref:`sort <node-fundamentals-sort>` and
 
       // no document matched
       // returns null
-      await coll.findOneAndDelete({ x: "off" }, { includeResultMetadata: false });
+      await coll.findOneAndDelete({ x: "off" });
 
 You can set the ``returnDocument`` setting in the ``options`` object for the
 ``findOneAndUpdate()`` and ``findOneAndDelete()`` methods, which lets

--- a/source/fundamentals/crud/compound-operations.txt
+++ b/source/fundamentals/crud/compound-operations.txt
@@ -51,8 +51,8 @@ configurable :ref:`sort <node-fundamentals-sort>` and
    of these methods.
    
    Starting in version 6.0, this setting defaults to ``false``, which
-   means that each method returns either the matched document or
-   ``null`` if no document is found. If you set
+   means that each method returns the matched document, or, if no
+   document is matched, it returns ``null``. If you set
    ``includeResultMetadata`` to ``true``, the method returns a
    ``ModifyResult`` type that contains the found document and additional
    metadata.

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -97,8 +97,8 @@ Version 6.x Breaking Changes
 - If you start a session on a client, then pass that session to a
   different client, the driver throws an error when you
   perform any operations in the session.
-- The ``includeResultMetadata`` option for ``findOneAnd...``
-  compound methods is ``false`` by default.
+- The ``includeResultMetadata`` option for compound operation methods is
+  ``false`` by default.
 
 .. _node-breaking-changes-v5.x:
 

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -97,6 +97,8 @@ Version 6.x Breaking Changes
 - If you start a session on a client, then pass that session to a
   different client, the driver throws an error when you
   perform any operations in the session.
+- The ``includeResultMetadata`` option for ``findOneAnd...``
+  compound methods is ``false`` by default.
 
 .. _node-breaking-changes-v5.x:
 

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -79,6 +79,11 @@ What's New in 6.0
    - If you start a session on a client, then pass that session to a
      different client, the driver throws an error when you
      perform any operations in the session.
+   
+   - The ``includeResultMetadata`` option for ``findOneAnd...``
+     compound methods is ``false`` by default. See the :ref:`Built-in
+     Methods <node-compound-operations-builtin>` section of the Compound
+     Operations guide for more information.
 
 The {+driver-short+} v6.0 release includes the following features:
 
@@ -196,9 +201,9 @@ The {+driver-short+} v5.7 release includes the following features:
 
 - A new option for ``findOneAnd...`` compound methods. The ``includeResultMetaData``
   option allows you to specify whether to include information about the
-  operation result. See the
-  :ref:`Compound Operations Built-in Methods <node-compound-operations-builtin>`
-  section for more information.
+  operation result. See the :ref:`Built-in Methods
+  <node-compound-operations-builtin>` section of the Compound Operations
+  guide for more information.
 
 - Support for change stream split events which enables processing change
   stream documents that exceed the 16MB maximum BSON size limit.

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -80,8 +80,8 @@ What's New in 6.0
      different client, the driver throws an error when you
      perform any operations in the session.
    
-   - The ``includeResultMetadata`` option for ``findOneAnd...``
-     compound methods is ``false`` by default. See the :ref:`Built-in
+   - The ``includeResultMetadata`` option for compound operation methods
+     is ``false`` by default. See the :ref:`Built-in
      Methods <node-compound-operations-builtin>` section of the Compound
      Operations guide for more information.
 
@@ -199,7 +199,8 @@ The {+driver-short+} v5.7 release includes the following features:
     instead, see the Legacy SSL options deprecated section in the
     v5.7.0 Release Highlights linked at the end of this section.
 
-- A new option for ``findOneAnd...`` compound methods. The ``includeResultMetaData``
+- A new option for compound operation methods. The
+  ``includeResultMetaData``
   option allows you to specify whether to include information about the
   operation result. See the :ref:`Built-in Methods
   <node-compound-operations-builtin>` section of the Compound Operations


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-31807>
Staging:
- [whats new](https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-31807-findone-behavior-change/whats-new/#what-s-new-in-6.0)
- [upgrade](https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-31807-findone-behavior-change/upgrade/#version-6.x-breaking-changes)
- [compound ops page admonition](https://docs-mongodbcom-staging.corp.mongodb.com/node/docsworker-xlarge/DOCSP-31807-findone-behavior-change/fundamentals/crud/compound-operations/#built-in-methods)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
