### PR TITLE
DOCSP-32806: metadata option for compound methods

### DIFF
--- a/source/fundamentals/crud/compound-operations.txt
+++ b/source/fundamentals/crud/compound-operations.txt
@@ -77,7 +77,7 @@ Suppose a collection contains only the following document:
 
 The following table shows how the value of the
 ``includeResultMetadata`` option changes the return type of
-the ``findOneAndDelete()`` method.
+the ``findOneAndDelete()`` method:
 
 .. list-table::
    :header-rows: 1

--- a/source/fundamentals/crud/compound-operations.txt
+++ b/source/fundamentals/crud/compound-operations.txt
@@ -81,7 +81,7 @@ the ``findOneAndDelete()`` method.
 
 .. list-table::
    :header-rows: 1
-   :widths: 15 20 65
+   :widths: 30 70
 
    * - Option Value
      - Syntax and Output

--- a/source/fundamentals/crud/compound-operations.txt
+++ b/source/fundamentals/crud/compound-operations.txt
@@ -81,7 +81,7 @@ the ``findOneAndDelete()`` method.
 
 .. list-table::
    :header-rows: 1
-   :widths: 30 70
+   :widths: 20 80
 
    * - Option Value
      - Syntax and Output

--- a/source/fundamentals/crud/compound-operations.txt
+++ b/source/fundamentals/crud/compound-operations.txt
@@ -75,19 +75,63 @@ Suppose a collection contains only the following document:
 
    { _id: 1, x: "on" }
 
-The following code shows how the value of the
+The following table shows how the value of the
 ``includeResultMetadata`` option changes the return type of
-the ``findOneAndDelete()`` method:
+the ``findOneAndDelete()`` method.
 
-.. code-block:: js
+.. list-table::
+   :header-rows: 1
+   :widths: 15 20 65
 
-   // default behavior
-   // returns { _id: 1, x: 'on' }
-   await coll.findOneAndDelete({ x: "on" });
+   * - Option Value
+     - Syntax and Output
 
-   // returns { lastErrorObject: { n: 1 }, value: { _id: 1, x: 'on' }, ok: 1, ... }
-   await coll.findOneAndDelete({ x: "on" }, { includeResultMetadata: true });
+   * - Default: ``false``
 
-   // no document matched
-   // returns null
-   await coll.findOneAndDelete({ x: "off" });
+     - *Document matched*
+
+       .. io-code-block::
+          :copyable: true
+
+          .. input::
+             :language: js
+
+             await coll.findOneAndDelete({ x: "on" });
+
+          .. output::
+             :language: js
+             :visible: false
+
+             { _id: 1, x: 'on' }
+
+       *No document matched*
+
+       .. io-code-block::
+          :copyable: true
+
+          .. input::
+             :language: js
+
+             await coll.findOneAndDelete({ x: "off" });
+
+          .. output::
+             :language: js
+             :visible: false
+
+             null   
+
+   * - ``true``
+
+     - .. io-code-block::
+          :copyable: true
+
+          .. input::
+             :language: js
+
+             await coll.findOneAndDelete({ x: "on" }, { includeResultMetadata: true });
+
+          .. output::
+             :language: js
+             :visible: false
+
+             { lastErrorObject: { n: 1 }, value: { _id: 1, x: 'on' }, ok: 1, ... }

--- a/source/fundamentals/crud/compound-operations.txt
+++ b/source/fundamentals/crud/compound-operations.txt
@@ -44,43 +44,50 @@ These methods accept an optional ``options`` object with
 configurable :ref:`sort <node-fundamentals-sort>` and
 :ref:`projection <node-fundamentals-project>` options.
 
-.. note:: includeResultMetadata Option
+You can also set the ``includeResultMetadata``
+option to specify the return type of each
+of these methods. To learn more about this option, see the
+:ref:`includeResultMetadata Option <node-compound-metadata-option>`
+section of this guide.
 
-   Starting in version 5.7, you can set the ``includeResultMetadata``
-   setting in the ``options`` object to specify the return type for each
-   of these methods.
+The ``findOneAndUpdate()`` and ``findOneAndDelete()`` methods take the
+``returnDocument`` setting, which specifies if the method returns the
+pre-update or post-update version of the modified document.
+
+.. _node-compound-metadata-option:
+
+includeResultMetadata Option
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``includeResultMetadata`` option determines the return type of the
+compound methods.
    
-   Starting in version 6.0, this setting defaults to ``false``, which
-   means that each method returns the matched document. If no
-   document is matched, each method returns ``null``. If you set
-   ``includeResultMetadata`` to ``true``, the method returns a
-   ``ModifyResult`` type that contains the found document and additional
-   metadata.
+This setting defaults to ``false``, which
+means that each method returns the matched document. If no
+document is matched, each method returns ``null``. If you set
+``includeResultMetadata`` to ``true``, the method returns a
+``ModifyResult`` type that contains the found document and additional
+metadata.
 
-   Suppose a collection contains only the following document:
+Suppose a collection contains only the following document:
 
-   .. code-block:: json
+.. code-block:: json
 
-      { _id: 1, x: "on" }
+   { _id: 1, x: "on" }
 
-   The following code shows how the value of the
-   ``includeResultMetadata`` option changes the return type of
-   the ``findOneAndDelete()`` method:
+The following code shows how the value of the
+``includeResultMetadata`` option changes the return type of
+the ``findOneAndDelete()`` method:
 
-   .. code-block:: js
+.. code-block:: js
 
-      // default behavior
-      // returns { _id: 1, x: 'on' }
-      await coll.findOneAndDelete({ x: "on" });
+   // default behavior
+   // returns { _id: 1, x: 'on' }
+   await coll.findOneAndDelete({ x: "on" });
 
-      // returns { lastErrorObject: { n: 1 }, value: { _id: 1, x: 'on' }, ok: 1, ... }
-      await coll.findOneAndDelete({ x: "on" }, { includeResultMetadata: true });
+   // returns { lastErrorObject: { n: 1 }, value: { _id: 1, x: 'on' }, ok: 1, ... }
+   await coll.findOneAndDelete({ x: "on" }, { includeResultMetadata: true });
 
-      // no document matched
-      // returns null
-      await coll.findOneAndDelete({ x: "off" });
-
-You can set the ``returnDocument`` setting in the ``options`` object for the
-``findOneAndUpdate()`` and ``findOneAndDelete()`` methods, which lets
-you specify if the method returns the pre-update or post-update version
-of the modified document.
+   // no document matched
+   // returns null
+   await coll.findOneAndDelete({ x: "off" });


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

**this PR can only be merged to v6.0+ because of the value of the default. When backporting, I will rearrange the information so that the correct default is described for pre-v6 versions**

JIRA - <https://jira.mongodb.org/browse/DOCSP-32806>
Staging - https://preview-mongodbrustagir.gatsbyjs.io/node/DOCSP-32806-metadata-content/fundamentals/crud/compound-operations/

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
