### PR TITLE
DOCSP-32806: metadata option for compound methods (#808)

### DIFF
--- a/source/fundamentals/crud/compound-operations.txt
+++ b/source/fundamentals/crud/compound-operations.txt
@@ -44,37 +44,94 @@ These methods accept an optional ``options`` object with
 configurable :ref:`sort <node-fundamentals-sort>` and
 :ref:`projection <node-fundamentals-project>` options.
 
-.. note:: includeResultMetadata Option
+You can also set the ``includeResultMetadata``
+option to specify the return type of each
+of these methods. To learn more about this option, see the
+:ref:`includeResultMetadata Option <node-compound-metadata-option>`
+section of this guide.
 
-   Starting in version 5.7, you can set the ``includeResultMetadata``
-   setting in the ``options`` object to specify the return type for each
-   of these methods. The setting defaults to ``true``, which means the
-   method returns a ``ModifyResult`` type. If you set
-   ``includeResultMetadata`` to ``false``, the method returns the
-   modified document.
+The ``findOneAndUpdate()`` and ``findOneAndDelete()`` methods take the
+``returnDocument`` setting, which specifies if the method returns the
+pre-update or post-update version of the modified document.
 
-   Suppose a collection contains the following document:
+.. _node-compound-metadata-option:
 
-   .. code-block:: json
+includeResultMetadata Option
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-      { _id: 1, x: "on" }
+The ``includeResultMetadata`` option determines the return type of the
+compound methods.
+   
+This setting defaults to ``true``, which
+means that each method returns a ``ModifyResult`` type that contains the
+found document and additional metadata. If you set
+``includeResultMetadata`` to ``false``, the method returns 
+the matched document. If no document is matched, each method returns
+``null``.
 
-   The following code shows the return type for ``findOneAndDelete()``
-   operations when ``includeResultMetadata`` is set to ``true`` and
-   ``false``:
+Suppose a collection contains only the following document:
 
-   .. code-block:: js
+.. code-block:: json
 
-      // returns { _id: 1, x: 'on' }
-      await coll.findOneAndDelete({ x: "on" }, { includeResultMetadata: false });
+   { _id: 1, x: "on" }
 
-      // returns { lastErrorObject: { n: 1 }, value: { _id: 1, x: 'on' }, ok: 1, ... }
-      await coll.findOneAndDelete({ x: "on" }, { includeResultMetadata: true });
+The following table shows how the value of the
+``includeResultMetadata`` option changes the return type of
+the ``findOneAndDelete()`` method:
 
-      // no document matched, returns null
-      await coll.findOneAndDelete({ x: "off" }, { includeResultMetadata: false });
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
 
-You can set the ``returnDocument`` setting in the ``options`` object for the
-``findOneAndUpdate()`` and ``findOneAndDelete()`` methods, which lets
-you specify if the method returns the pre-update or post-update version
-of the modified document.
+   * - Option Value
+     - Syntax and Output
+
+   * - Default: ``true``
+
+     - .. io-code-block::
+          :copyable: true
+
+          .. input::
+             :language: js
+
+             await coll.findOneAndDelete({ x: "on" });
+
+          .. output::
+             :language: js
+             :visible: false
+
+             { lastErrorObject: { n: 1 }, value: { _id: 1, x: 'on' }, ok: 1, ... }
+
+   * - ``false``
+
+     - *Document matched*
+
+       .. io-code-block::
+          :copyable: true
+
+          .. input::
+             :language: js
+
+             await coll.findOneAndDelete({ x: "on" }, { includeResultMetadata: false });
+
+          .. output::
+             :language: js
+             :visible: false
+
+             { _id: 1, x: 'on' }
+
+       *No document matched*
+
+       .. io-code-block::
+          :copyable: true
+
+          .. input::
+             :language: js
+
+             await coll.findOneAndDelete({ x: "off" }, { includeResultMetadata: false });
+
+          .. output::
+             :language: js
+             :visible: false
+
+             null


### PR DESCRIPTION
**FOR V5.8 and V5.7** #808

# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-32806>
Staging - https://preview-mongodbrustagir.gatsbyjs.io/node/v5.8/fundamentals/crud/compound-operations/#includeresultmetadata-option

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
