### PR TITLE
DOCSP-31790 update title to alphabetize legacy product menu

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -1,5 +1,5 @@
 name = "node"
-title = "Node.js"
+title = "Node.js Driver"
 intersphinx = [
     "https://www.mongodb.com/docs/manual/objects.inv",
     "https://www.mongodb.com/docs/drivers/objects.inv",


### PR DESCRIPTION
Hello again @caitlindavey!

Here's the PR for renaming the Node.js Driver title field in the snooty.toml files so that DOP can set up the legacy menu to pull from that field. Please backport to older versions if we're good to go.

This changes two elements on the page: the top level on the level nav and the breadcrumb verbiage. It was previously just 'Node.js' so adding 'Driver' seems pretty key. :)

Here's my[ build log ](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=653ab1853ede3ec111675c7d).

Thanks for your review & merge!
Sarah

# Pull Request Info

JIRA - <https://jira.mongodb.org/browse/DOCSP-31790>
Staging - <https://preview-mongodbsarahemlin.gatsbyjs.io/node/DOCSP-31790/>
