### PR TITLE
Update deployments section for style guide compliance and contextual fit

### DIFF
--- a/source/includes/fact-atlas-compatible.rst
+++ b/source/includes/fact-atlas-compatible.rst
@@ -1,4 +1,4 @@
-You can use the {+driver-short+} to connect and |page-topic| for
-deployments hosted in the following environments:
+You can use the {+driver-short+} to connect and |page-topic| to MongoDB
+deployments running on one of the following hosted services or editions:
 
 .. include:: /includes/fact-environments.rst

--- a/source/includes/fact-atlas-link.rst
+++ b/source/includes/fact-atlas-link.rst
@@ -1,2 +1,2 @@
-You can |link-topic-ing| when you connect to a MongoDB Atlas deployment. 
+You can |link-topic-ing| when you connect to a MongoDB Atlas deployment.
 To learn more, see the |atlas-url| Atlas UI tutorial.

--- a/source/includes/fact-atlas-link.rst
+++ b/source/includes/fact-atlas-link.rst
@@ -1,2 +1,2 @@
-To learn more about |link-topic-ing| for deployments hosted in MongoDB
-Atlas, see |atlas-url|.
+You can |link-topic-ing| when you connect to a MongoDB Atlas deployment. 
+To learn more, see the |atlas-url| Atlas UI tutorial.

--- a/source/includes/fact-environments.rst
+++ b/source/includes/fact-environments.rst
@@ -1,7 +1,7 @@
 - `MongoDB Atlas
-  <https://www.mongodb.com/docs/atlas>`__: The fully
+  <https://www.mongodb.com/docs/atlas>`__: the fully
   managed service for MongoDB deployments in the cloud
-- :ref:`MongoDB Enterprise <install-mdb-enterprise>`: The
+- :ref:`MongoDB Enterprise <install-mdb-enterprise>`: the
   subscription-based, self-managed version of MongoDB
-- :ref:`MongoDB Community <install-mdb-community-edition>`: The
+- :ref:`MongoDB Community <install-mdb-community-edition>`: the
   source-available, free-to-use, and self-managed version of MongoDB

--- a/source/quick-reference.txt
+++ b/source/quick-reference.txt
@@ -16,11 +16,13 @@ Quick Reference
 This page shows the driver syntax for several MongoDB commands and links to
 their related reference and API documentation.
 
+Connect to a Compatible Deployment
+Use the Node.js Driver to 
 Compatibility
 -------------
 
-.. |page-topic| replace:: execute commands
-.. |link-topic-ing| replace:: performing common CRUD operations in the Atlas UI
+.. |page-topic| replace:: run commands
+.. |link-topic-ing| replace:: run read and write operations directly from the Atlas UI
 
 .. |atlas-url| replace:: :atlas:`Create, View, Update, and Delete Documents </atlas-ui/documents>`
 

--- a/source/quick-reference.txt
+++ b/source/quick-reference.txt
@@ -22,7 +22,7 @@ Connect to a Compatible MongoDB Deployment
 .. |page-topic| replace:: run commands
 .. |link-topic-ing| replace:: run read and write operations directly from the Atlas UI
 
-.. |atlas-url| replace:: :atlas:`atlas-ui/documents/`
+.. |atlas-url| replace:: :atlas:`Create, View, Update, and Delete Documents <atlas-ui/documents/>`
 
 .. include:: /includes/fact-atlas-compatible.rst
 .. include:: /includes/fact-atlas-link.rst

--- a/source/quick-reference.txt
+++ b/source/quick-reference.txt
@@ -16,15 +16,13 @@ Quick Reference
 This page shows the driver syntax for several MongoDB commands and links to
 their related reference and API documentation.
 
-Connect to a Compatible Deployment
-Use the Node.js Driver to 
-Compatibility
--------------
+Connect to a Compatible MongoDB Deployment
+------------------------------------------
 
 .. |page-topic| replace:: run commands
 .. |link-topic-ing| replace:: run read and write operations directly from the Atlas UI
 
-.. |atlas-url| replace:: :atlas:`Create, View, Update, and Delete Documents </atlas-ui/documents>`
+.. |atlas-url| replace:: :atlas:`atlas-ui/documents/`
 
 .. include:: /includes/fact-atlas-compatible.rst
 .. include:: /includes/fact-atlas-link.rst


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

These proposed changes address the following issues:

- The style guide mentions using "run" instead of "[executes](https://www.mongodb.com/docs/meta/style-guide/terminology/terms-for-global-audience/)"
- The style guide mentions explaining abbreviations before their first usage on a page in [abbreviations](https://www.mongodb.com/docs/meta/style-guide/style/abbreviations/#abbreviations).
- I think "compatibility", used as the heading text, usually signals information about matching versions and products that work together. However, the content of the section omits specific information about this. This title text also clashes the [landing page](https://www.mongodb.com/docs/drivers/node/current/#compatibility) and corresponding section that use the same term which could confuse the user.
- The paragraph after the list items transitions to Atlas UI without signaling that the subject is changing.
- I think introducing Atlas, Enterprise download, and Community download as "environments" is inaccurate. I think Atlas is a [deployment environment](https://en.wikipedia.org/wiki/Deployment_environment),but Enterprise and Community Edition are versions are the MongoDB binary, from which you can launch a deployment in a separate environment.


JIRA - None
Staging - [Quick Reference section](https://preview-mongodbcchomongodb.gatsbyjs.io/node/111323-compatibility-include/quick-reference/)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
