### PR TITLE
DOCSP-23996 Add enableUtf8Validation URI Option

### DIFF
--- a/source/fundamentals/connection/connection-options.txt
+++ b/source/fundamentals/connection/connection-options.txt
@@ -77,18 +77,16 @@ parameters of the connection URI to specify the behavior of the client.
      - boolean
      - ``true``
      -   Specifies if utf8 validation for the connection is enabled. 
-         When utf8 validation is enabled, MongoDB throws an error when 
+         When enabled, MongoDB throws an error when 
          it attempts to convert data that contains invalid 
          `UTF-8 characters <https://en.wikipedia.org/wiki/UTF-8>`__. 
          The validation adds processing overhead since it needs to check 
          the data.
 
          Specifying ``false``. Disables utf8 validation for the 
-         connection. 
-
-         If you disable validation, your application avoids the 
-         validation processing overhead but cannot guarantee consistent 
-         presentation of invalid UTF-8 data.
+         connection. If you disable validation, your application avoids 
+         the validation processing overhead but cannot guarantee 
+         consistent presentation of invalid UTF-8 data.
 
    * - **heartbeatFrequencyMS**
      - integer greater than or equal to 500

--- a/source/fundamentals/connection/connection-options.txt
+++ b/source/fundamentals/connection/connection-options.txt
@@ -83,7 +83,7 @@ parameters of the connection URI to specify the behavior of the client.
          The validation adds processing overhead since it needs to check 
          the data.
 
-         Specifying ``false``. Disables utf8 validation for the 
+         Specifying ``false`` disables utf8 validation for the 
          connection. If you disable validation, your application avoids 
          the validation processing overhead but cannot guarantee 
          consistent presentation of invalid UTF-8 data.

--- a/source/fundamentals/connection/connection-options.txt
+++ b/source/fundamentals/connection/connection-options.txt
@@ -73,6 +73,26 @@ parameters of the connection URI to specify the behavior of the client.
      - Specifies whether to force dispatch **all** operations to the host
        specified in the connection URI.
 
+   * - **enableUtf8Validation**
+     - boolean
+     - ``true``
+     - Possible values are:
+
+       - ``true``. Enables utf8 validation for the connection. 
+         If utf8 validation is enabled, MongoDB throws an error when it 
+         attempts to convert data that contains invalid 
+         `UTF-8 characters <https://en.wikipedia.org/wiki/UTF-8>`__. 
+         The validation adds processing overhead since it needs to check 
+         the data.
+    
+       - ``false``. Disables utf8 validation for the connection. 
+
+         .. warning::
+
+           If you disable validation, your application avoids the 
+           validation processing overhead but cannot guarantee consistent 
+           presentation of invalid UTF-8 data.
+
    * - **heartbeatFrequencyMS**
      - integer greater than or equal to 500
      - ``null``

--- a/source/fundamentals/connection/connection-options.txt
+++ b/source/fundamentals/connection/connection-options.txt
@@ -76,22 +76,19 @@ parameters of the connection URI to specify the behavior of the client.
    * - **enableUtf8Validation**
      - boolean
      - ``true``
-     - Possible values are:
-
-       - ``true``. Enables utf8 validation for the connection. 
-         If utf8 validation is enabled, MongoDB throws an error when it 
-         attempts to convert data that contains invalid 
+     -   Specifies if utf8 validation for the connection is enabled. 
+         When utf8 validation is enabled, MongoDB throws an error when 
+         it attempts to convert data that contains invalid 
          `UTF-8 characters <https://en.wikipedia.org/wiki/UTF-8>`__. 
          The validation adds processing overhead since it needs to check 
          the data.
-    
-       - ``false``. Disables utf8 validation for the connection. 
 
-         .. warning::
+         Specifying ``false``. Disables utf8 validation for the 
+         connection. 
 
-           If you disable validation, your application avoids the 
-           validation processing overhead but cannot guarantee consistent 
-           presentation of invalid UTF-8 data.
+         If you disable validation, your application avoids the 
+         validation processing overhead but cannot guarantee consistent 
+         presentation of invalid UTF-8 data.
 
    * - **heartbeatFrequencyMS**
      - integer greater than or equal to 500


### PR DESCRIPTION
# Pull Request Info

Adding the connection URI option to the connection-options page. It came out in tech review for 
https://jira.mongodb.org/browse/DOCSP-23996 that the `enableUtf8Validation` is both a [driver setting](https://www.mongodb.com/docs/drivers/node/current/fundamentals/bson/utf8-validation/) and a connection string option (currently only supported for the node js driver). This edit adds the option to node URI options. 

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-23996
Staging - https://preview-mongodbianfmongodb.gatsbyjs.io/node/DOCSP-23996/fundamentals/connection/connection-options/

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
