### PR TITLE
DOCSP-35143: Remove await operators

### DIFF
--- a/source/code-snippets/crud/pizza.js
+++ b/source/code-snippets/crud/pizza.js
@@ -16,7 +16,7 @@ async function run() {
     const orders = database.collection("orders");
     // start find crud example
     // Search for orders by name and within a specific date range
-    const findResult = await orders.find({
+    const findResult = orders.find({
       name: "Lemony Snicket",
       date: {
         $gte: new Date(new Date().setHours(00, 00, 00)),
@@ -27,7 +27,7 @@ async function run() {
     console.log(await findResult.toArray());
     // start aggregate crud example
     // Group orders by status within the last week
-    const aggregateResult = await orders.aggregate([
+    const aggregateResult = orders.aggregate([
       {
         $match: {
           date: {

--- a/source/fundamentals/crud/read-operations/retrieve.txt
+++ b/source/fundamentals/crud/read-operations/retrieve.txt
@@ -4,6 +4,13 @@
 Retrieve Data
 =============
 
+.. facet::
+   :name: genre
+   :values: reference
+
+.. meta::
+   :keywords: node.js, code example, find one, find many
+
 .. contents:: On this page
    :local:
    :backlinks: none
@@ -129,8 +136,11 @@ a ``null`` value if there are no matches.
         ...
       ]
 
-See the :ref:`find() <node-usage-find>` and :ref:`findOne()
-<node-usage-findone>` for fully-runnable examples.
+For runnable code examples that demonstrate find operations, see the following
+usage examples:
+
+- :ref:`node-usage-find`
+- :ref:`node-usage-findone`
 
 Aggregate Data from Documents
 -----------------------------

--- a/source/fundamentals/crud/read-operations/retrieve.txt
+++ b/source/fundamentals/crud/read-operations/retrieve.txt
@@ -145,14 +145,14 @@ Additional Information
 For runnable code examples that demonstrate find operations, see the following
 usage examples:
 
-- :ref:`node-usage-find`
 - :ref:`node-usage-findone`
+- :ref:`node-usage-find`
 
-For more information about the find() and findOne() methods, see the following
-Server manual documentation:
+For more information about the ``findOne()`` and ``find()`` methods, see the
+following Server manual documentation:
 
-- :manual:`find() </reference/method/db.collection.find/>`
 - :manual:`findOne() </reference/method/db.collection.findOne/>`
+- :manual:`find() </reference/method/db.collection.find/>`
 
 Aggregate Data from Documents
 -----------------------------
@@ -199,7 +199,8 @@ Additional Information
 ~~~~~~~~~~~~~~~~~~~~~~
 
 For more information on how to construct an aggregation pipeline, see
-:manual:`Aggregation Operations </aggregation>` in the Server manual.
+the :ref:`node-aggregation` guide or :manual:`Aggregation Operations </aggregation>`
+in the Server manual.
 
 .. _node-fundamentals-watch:
 

--- a/source/fundamentals/crud/read-operations/retrieve.txt
+++ b/source/fundamentals/crud/read-operations/retrieve.txt
@@ -99,6 +99,9 @@ see the :ref:`node-fundamentals-query-document` guide.
 
       const findResult = await myColl.findOne({}, options);
 
+   For more information about projecting document fields, see the
+   :ref:`node-fundamentals-project` guide.
+
 The ``find()`` method returns a ``Cursor`` instance from which you can
 access the matched documents. The ``findOne()`` method returns a ``Promise``
 instance, which you can resolve to access either the matching document or

--- a/source/fundamentals/crud/read-operations/retrieve.txt
+++ b/source/fundamentals/crud/read-operations/retrieve.txt
@@ -72,8 +72,8 @@ see the :ref:`node-fundamentals-query-document` guide.
 
    .. code-block:: javascript
 
-      await myColl.find(); // no query
-      await myColl.find({}); // empty query
+      myColl.find(); // no query
+      myColl.find({}); // empty query
    
    If you don't pass a query or pass an empty query
    to the ``findOne()`` method, the operation returns a single
@@ -82,7 +82,7 @@ see the :ref:`node-fundamentals-query-document` guide.
    You can specify options in a find operation even when you pass an
    empty query. For example, the following code shows how you can
    specify a projection as an option while executing a find operation
-   with an empty query parameter:
+   that receives an empty query parameter:
 
    .. code-block:: javascript
 
@@ -92,10 +92,10 @@ see the :ref:`node-fundamentals-query-document` guide.
 
       const findResult = await myColl.findOne({}, options);
 
-If you resolve the ``Promise`` returned by ``find()``, you receive
-a reference to a ``Cursor`` with which you can navigate matched documents.
-If you resolve the ``Promise`` returned by ``findOne()``, you receive the
-matching document or ``null`` if there are no matches.
+The ``find()`` method returns a ``Cursor`` instance from which you can
+access the matched documents. The ``findOne()`` method returns a ``Promise``
+instance, which you can resolve to access either the matching document or
+a ``null`` value if there are no matches.
 
 .. example::
 

--- a/source/fundamentals/crud/read-operations/retrieve.txt
+++ b/source/fundamentals/crud/read-operations/retrieve.txt
@@ -139,11 +139,20 @@ a ``null`` value if there are no matches.
         ...
       ]
 
+Additional Information
+~~~~~~~~~~~~~~~~~~~~~~
+
 For runnable code examples that demonstrate find operations, see the following
 usage examples:
 
 - :ref:`node-usage-find`
 - :ref:`node-usage-findone`
+
+For more information about the find() and findOne() methods, see the following
+Server manual documentation:
+
+- :manual:`find() </reference/method/db.collection.find/>`
+- :manual:`findOne() </reference/method/db.collection.findOne/>`
 
 Aggregate Data from Documents
 -----------------------------
@@ -186,8 +195,11 @@ group, and arrange the result data from a collection.
         { _id: 'created', count: 9 }
       ]
 
-See the {+mdb-server+} manual pages on :manual:`aggregation </aggregation>`
-for more information on how to construct an aggregation pipeline.
+Additional Information
+~~~~~~~~~~~~~~~~~~~~~~
+
+For more information on how to construct an aggregation pipeline, see
+:manual:`Aggregation Operations </aggregation>` in the Server manual.
 
 .. _node-fundamentals-watch:
 
@@ -213,8 +225,11 @@ data whenever write operations are executed on the collection.
       :start-after: start watch crud example
       :end-before: end watch crud example
 
-For a runnable example of the ``watch()`` method using the NodeJS driver, see
-the :ref:`change streams <node-usage-watch>` usage example.
+Additional Information
+~~~~~~~~~~~~~~~~~~~~~~
+
+For a runnable example of the ``watch()`` method, see the
+:ref:`Watch for Changes <node-usage-watch>` usage example.
 
 .. _node-retrieve-instruqt-lab:
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-35143>
Staging - <https://preview-mongodbnorareidy.gatsbyjs.io/node/DOCSP-35143-remove-await/fundamentals/crud/read-operations/retrieve/>

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
