### PR TITLE
[v4.14] DOCSP-35296 Fix swapped link text (#844)

### DIFF
--- a/source/fundamentals/monitoring/cluster-monitoring.txt
+++ b/source/fundamentals/monitoring/cluster-monitoring.txt
@@ -160,10 +160,10 @@ one of the following possible values:
    * - ``RSArbiter``
      - Arbiter instance
    * - ``RSOther``
-     - See the `RSGhost specification <https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#rsghost-and-rsother>`_
+     - See the `RSGhost and RSOther specification <https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#rsghost-and-rsother>`__
        for more details
    * - ``RSGhost``
-     - See the `RSOther specification <https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#rsghost-and-rsother>`_
+     - See the `RSGhost and RSOther specification <https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#rsghost-and-rsother>`__
        for more details
 
 serverHeartbeatStarted


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v4.14`:
 - [DOCSP-35296 Fix swapped link text (#844)](https://github.com/mongodb/docs-node/pull/844)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)