### PR TITLE
DOCSP-35195: fix duration values

### DIFF
--- a/source/fundamentals/monitoring/command-monitoring.txt
+++ b/source/fundamentals/monitoring/command-monitoring.txt
@@ -97,7 +97,7 @@ commandSucceeded
      commandName: "find",
      address: 'localhost:27017',
      connectionId: 812613,
-     duration: 1586380205,
+     duration: 15,
      reply: {
        cursor: {
          firstBatch: [
@@ -128,5 +128,5 @@ commandFailed
      address: 'localhost:27017',
      connectionId: 812613,
      failure: Error("something failed"),
-     duration: 1586380205
+     duration: 11
    }


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-35195>
Staging - 
[CommandSucceeded](https://preview-mongodbcchomongodb.gatsbyjs.io/node/DOCSP-35195-fix-duration/fundamentals/monitoring/command-monitoring/#commandsucceeded)
[CommandFailed](https://preview-mongodbcchomongodb.gatsbyjs.io/node/DOCSP-35195-fix-duration/fundamentals/monitoring/command-monitoring/#commandfailed)


## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
