### PR TITLE
DOCSP-35367: remove unsupported single timeout option

### DIFF
--- a/source/fundamentals/connection/connection-options.txt
+++ b/source/fundamentals/connection/connection-options.txt
@@ -237,11 +237,6 @@ parameters of the connection URI to specify the behavior of the client.
      - ``false``
      - The ``ssl`` is an alias for the ``tls`` option.
 
-   * - **timeoutMS**
-     - non-negative integer
-     - unset (feature is not enabled by default)
-     - Specifies the timeout, in milliseconds, for the full execution of an operation.
-
    * - **tls**
      - boolean
      - ``false``


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-35367>
Staging - https://preview-mongodbrustagir.gatsbyjs.io/node/DOCSP-35367-remove-timeoutms-opt/fundamentals/connection/connection-options/

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
