### PR TITLE
DOCSP-37612: convert compatibility to sharedinclude

### DIFF
--- a/source/compatibility.txt
+++ b/source/compatibility.txt
@@ -29,7 +29,7 @@ The first column lists the driver version.
 
 .. sharedinclude:: dbx/compatibility-table-legend.rst
 
-.. include:: /includes/mongodb-compatibility-table-node.rst
+.. sharedinclude:: dbx/mongodb-compatibility-table-node.rst
 
 Language Compatibility
 ----------------------


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-37612>
Staging - [Compatibility](https://preview-mongodbcchomongodb.gatsbyjs.io/node/DOCSP-37612-compat-shared-include/compatibility/#compatibility-table-legend)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
