### PR TITLE
DOCSP-32561: Exact versions in upgrade guide

### DIFF
--- a/source/aggregation-tutorials/filtered-subset.txt
+++ b/source/aggregation-tutorials/filtered-subset.txt
@@ -46,13 +46,13 @@ documents describing people. Each document includes a person's name,
 date of birth, vocation, and other details.
 
 Before You Get Started
-----------------------
+-----------------------
 
 Before you start this tutorial, complete the
 :ref:`node-agg-tutorial-template-app` instructions to set up a working
 Node.js application.
 
-After you set up the app, access the ``persons`` collection by adding the
+After you set up the app, access the ``people`` collection by adding the
 following code to the application:
 
 .. literalinclude:: /includes/aggregation/filtered-subset.js

--- a/source/aggregation-tutorials/filtered-subset.txt
+++ b/source/aggregation-tutorials/filtered-subset.txt
@@ -46,13 +46,13 @@ documents describing people. Each document includes a person's name,
 date of birth, vocation, and other details.
 
 Before You Get Started
------------------------
+----------------------
 
 Before you start this tutorial, complete the
 :ref:`node-agg-tutorial-template-app` instructions to set up a working
 Node.js application.
 
-After you set up the app, access the ``people`` collection by adding the
+After you set up the app, access the ``persons`` collection by adding the
 following code to the application:
 
 .. literalinclude:: /includes/aggregation/filtered-subset.js

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -73,6 +73,7 @@ planned upgrade version. For example, if you are upgrading the driver
 from v3.x to v5.x, address all breaking changes listed under v4.0 and
 v5.0.
 
+.. _node-breaking-changes-v6.x:
 .. _node-breaking-changes-v6.0:
 
 Version 6.0 Breaking Changes
@@ -137,6 +138,7 @@ Version 6.0 Breaking Changes
   removed support for version 1.x.
 - Raised the optional ``zstd`` dependency minimum version to 1.1.0.
 
+.. _node-breaking-changes-v5.x:
 .. _node-breaking-changes-v5.0:
 
 Version 5.0 Breaking Changes
@@ -190,6 +192,7 @@ Version 5.0 Breaking Changes
   - ``ObjectID`` type removed in favor of ``ObjectId``
   - ``AsyncIterator`` interface removed in favor of ``AsyncGenerator``
 
+.. _node-breaking-changes-v4.x:
 .. _node-breaking-changes-v4.0:
 
 Version 4.0 Breaking Changes

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -70,12 +70,12 @@ The breaking changes in this section are categorized by the major
 version releases that introduced them. When upgrading driver versions,
 address all the breaking changes between your current version and the
 planned upgrade version. For example, if you are upgrading the driver
-from v3.x to v5.x, address all breaking changes listed under v4.x and
-v5.x.
+from v3.x to v5.x, address all breaking changes listed under v4.0 and
+v5.0.
 
-.. _node-breaking-changes-v6.x:
+.. _node-breaking-changes-v6.0:
 
-Version 6.x Breaking Changes
+Version 6.0 Breaking Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Version 6.0 of the {+driver-short+} requires Node.js v16.20.1 or later.
@@ -84,7 +84,7 @@ Version 6.x Breaking Changes
 - The driver removes support for the ``collStats`` operation. Use the
   :manual:`$collStats </reference/operator/aggregation/collStats>` aggregation operator
   instead.
-- The driver deprecates all the ``ssl``-prefixed options and the
+- The driver removes all the deprecated ``ssl``-prefixed options and the
   ``tlsCertificateFile`` option in the ``MongoClientOptions`` type.
   Create a ``SecureContext`` object or set the ``tls``-prefixed options
   in your ``MongoClientOptions`` instance instead.
@@ -137,14 +137,13 @@ Version 6.x Breaking Changes
   removed support for version 1.x.
 - Raised the optional ``zstd`` dependency minimum version to 1.1.0.
 
-.. _node-breaking-changes-v5.x:
+.. _node-breaking-changes-v5.0:
 
-Version 5.x Breaking Changes
+Version 5.0 Breaking Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Driver versions 5.x are not compatible with Node.js
-  v12 or earlier. If you want to use this version of the driver, you must
-  use Node.js v14.20.1 or greater.
+- The driver is no longer compatible with Node.js v12 or earlier. If you want to use
+  this version of the driver, you must use Node.js v14.20.1 or greater.
 
 - The driver removes support for callbacks in favor of a promise-based API.
   The following list provides some strategies for callback users to adopt this
@@ -191,14 +190,13 @@ Version 5.x Breaking Changes
   - ``ObjectID`` type removed in favor of ``ObjectId``
   - ``AsyncIterator`` interface removed in favor of ``AsyncGenerator``
 
-.. _node-breaking-changes-v4.x:
+.. _node-breaking-changes-v4.0:
 
-Version 4.x Breaking Changes
+Version 4.0 Breaking Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Driver versions 4.x are not compatible with Node.js
-  v12.8 or earlier. If you want to use this version of the driver, You must
-  use Node.js v12.9 or greater.
+- The driver is no longer compatible with Node.js v12.8 or earlier. If you
+  want to use this version of the driver, you must use Node.js v12.9 or greater.
 
 - ``Cursor`` types no longer extend ``Readable`` directly.
 

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -244,7 +244,7 @@ What's New in 6.0
 .. warning:: Breaking Changes in v6.0
 
    This driver version introduces breaking changes. For a list of these changes, see
-   the :ref:`Version 6.x Breaking Changes section <node-breaking-changes-v6.x>` in the
+   the :ref:`Version 6.0 Breaking Changes section <node-breaking-changes-v6.0>` in the
    Upgrade guide.
 
 The {+driver-short+} v6.0 release includes the following features:
@@ -538,7 +538,7 @@ What's New in 5.0
 .. warning:: Breaking Changes in v5.0
 
    This driver version introduces breaking changes. For a list of these changes, see
-   the :ref:`Version 5.x Breaking Changes section <node-breaking-changes-v5.x>` in the
+   the :ref:`Version 5.0 Breaking Changes section <node-breaking-changes-v5.0>` in the
    Upgrade guide.
 
 New features of the 5.0 {+driver-short+} release include:
@@ -912,7 +912,7 @@ What's New in 4.0
 .. warning:: Breaking Changes in v4.0
 
    This driver version introduces breaking changes. For a list of these changes, see
-   the :ref:`Version 4.x Breaking Changes section <node-breaking-changes-v4.x>` in
+   the :ref:`Version 4.0 Breaking Changes section <node-breaking-changes-v4.0>` in
    the Upgrade guide.
 
 New features of the 4.0 Node.js driver release include:


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

Note: all breaking changes were introduced in major versions, so ".x" has been changed to ".0".

JIRA - https://jira.mongodb.org/browse/DOCSP-32561
Staging - https://preview-mongodbnorareidy.gatsbyjs.io/node/DOCSP-32561-exact-versions/upgrade/

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
