### PR TITLE
DOCSP-43242: Improve UTF-8 validation documentation to clarify validation occurs on decoded data only

### DIFF
--- a/source/fundamentals/bson/utf8-validation.txt
+++ b/source/fundamentals/bson/utf8-validation.txt
@@ -25,9 +25,10 @@ processing overhead since it needs to check the data.
 If you *disable* validation, your application avoids the validation processing
 overhead, but cannot guarantee consistent presentation of invalid UTF-8 data.
 
-The driver enables UTF-8 validation on documents coming from MongoDB by default. 
-It checks incoming documents for any characters that are not encoded in a 
-valid UTF-8 format when it transfers data from MongoDB to your application.
+By default, the driver enables UTF-8 validation on BSON strings in documents 
+from MongoDB. It checks incoming documents for any characters that are not 
+encoded in a valid UTF-8 format when it transfers data from MongoDB to your 
+application.
 
 .. note::
 

--- a/source/fundamentals/bson/utf8-validation.txt
+++ b/source/fundamentals/bson/utf8-validation.txt
@@ -25,10 +25,9 @@ processing overhead since it needs to check the data.
 If you *disable* validation, your application avoids the validation processing
 overhead, but cannot guarantee consistent presentation of invalid UTF-8 data.
 
-By default, the driver enables UTF-8 validation on BSON strings in documents
-from MongoDB. It checks incoming strings for any characters that are not 
-encoded in a valid UTF-8 format when it transfers data from MongoDB to your 
-application.
+By default, the driver enables UTF-8 validation on data from MongoDB. 
+It checks incoming strings for any characters that are not encoded in a 
+valid UTF-8 format when it transfers data from MongoDB to your application.
 
 .. note::
 

--- a/source/fundamentals/bson/utf8-validation.txt
+++ b/source/fundamentals/bson/utf8-validation.txt
@@ -31,7 +31,7 @@ valid UTF-8 format when it parses data sent from MongoDB to your application.
 
 .. note::
 
-   The current version of the {+driver-short+} automatically substitutes invalid
+   This version of the {+driver-short+} automatically substitutes invalid
    `lone surrogates <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#utf-16_characters_unicode_code_points_and_grapheme_clusters>`__
    with the `replacement character <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toWellFormed>`__ 
    before validation when you send data to MongoDB. Therefore, the validation

--- a/source/fundamentals/bson/utf8-validation.txt
+++ b/source/fundamentals/bson/utf8-validation.txt
@@ -33,7 +33,7 @@ valid UTF-8 format when it transfers data from MongoDB to your application.
 
    The current version of the {+driver-short+} automatically substitutes
    invalid UTF-8 characters with alternate valid UTF-8 ones before
-   validation when you send data to MongoDB. Therefore, the validation
+   validation when you receive data from MongoDB. Therefore, the validation
    only throws an error when the setting is enabled and the driver
    receives invalid UTF-8 document data from MongoDB.
 

--- a/source/fundamentals/bson/utf8-validation.txt
+++ b/source/fundamentals/bson/utf8-validation.txt
@@ -25,7 +25,7 @@ processing overhead since it needs to check the data.
 If you *disable* validation, your application avoids the validation processing
 overhead, but cannot guarantee consistent presentation of invalid UTF-8 data.
 
-The driver enables UTF-8 validation by default. It checks documents for any
+The driver enables UTF-8 validation by default for sdfjk. It checks documents for any
 characters that are not encoded in a valid UTF-8 format when it transfers data
 between your application and MongoDB.
 

--- a/source/fundamentals/bson/utf8-validation.txt
+++ b/source/fundamentals/bson/utf8-validation.txt
@@ -25,9 +25,9 @@ processing overhead since it needs to check the data.
 If you *disable* validation, your application avoids the validation processing
 overhead, but cannot guarantee consistent presentation of invalid UTF-8 data.
 
-The driver enables UTF-8 validation by default for sdfjk. It checks documents for any
-characters that are not encoded in a valid UTF-8 format when it transfers data
-between your application and MongoDB.
+The driver enables UTF-8 validation on documents coming from MongoDB by default. 
+It checks incoming BSON strings for any characters that are not encoded in a 
+valid UTF-8 format when it transfers data from MongoDB to your application.
 
 .. note::
 

--- a/source/fundamentals/bson/utf8-validation.txt
+++ b/source/fundamentals/bson/utf8-validation.txt
@@ -26,7 +26,7 @@ If you *disable* validation, your application avoids the validation processing
 overhead, but cannot guarantee consistent presentation of invalid UTF-8 data.
 
 The driver enables UTF-8 validation on documents coming from MongoDB by default. 
-It checks incoming BSON strings for any characters that are not encoded in a 
+It checks incoming documents for any characters that are not encoded in a 
 valid UTF-8 format when it transfers data from MongoDB to your application.
 
 .. note::

--- a/source/fundamentals/bson/utf8-validation.txt
+++ b/source/fundamentals/bson/utf8-validation.txt
@@ -25,8 +25,8 @@ processing overhead since it needs to check the data.
 If you *disable* validation, your application avoids the validation processing
 overhead, but cannot guarantee consistent presentation of invalid UTF-8 data.
 
-By default, the driver enables UTF-8 validation on BSON strings in documents 
-from MongoDB. It checks incoming documents for any characters that are not 
+By default, the driver enables UTF-8 validation on BSON strings in documents
+from MongoDB. It checks incoming strings for any characters that are not 
 encoded in a valid UTF-8 format when it transfers data from MongoDB to your 
 application.
 

--- a/source/fundamentals/bson/utf8-validation.txt
+++ b/source/fundamentals/bson/utf8-validation.txt
@@ -29,14 +29,6 @@ The driver enables UTF-8 validation on documents coming from MongoDB by default.
 It checks incoming documents for any characters that are not encoded in a 
 valid UTF-8 format when it transfers data from MongoDB to your application.
 
-.. note::
-
-   The current version of the {+driver-short+} automatically substitutes
-   invalid UTF-8 characters with alternate valid UTF-8 ones before
-   validation when you receive data from MongoDB. Therefore, the validation
-   only throws an error when the setting is enabled and the driver
-   receives invalid UTF-8 document data from MongoDB.
-
 Read the sections below to learn how to set UTF-8 validation using the
 {+driver-short+}.
 

--- a/source/fundamentals/bson/utf8-validation.txt
+++ b/source/fundamentals/bson/utf8-validation.txt
@@ -29,6 +29,14 @@ The driver enables UTF-8 validation on documents coming from MongoDB by default.
 It checks incoming documents for any characters that are not encoded in a 
 valid UTF-8 format when it transfers data from MongoDB to your application.
 
+.. note::
+
+   The current version of the {+driver-short+} automatically substitutes
+   invalid UTF-8 characters with alternate valid UTF-8 ones before
+   validation when you send data to MongoDB. Therefore, the validation
+   only throws an error when the setting is enabled and the driver
+   receives invalid UTF-8 document data from MongoDB.
+
 Read the sections below to learn how to set UTF-8 validation using the
 {+driver-short+}.
 

--- a/source/fundamentals/bson/utf8-validation.txt
+++ b/source/fundamentals/bson/utf8-validation.txt
@@ -18,6 +18,11 @@ In this guide, you can learn how to enable or disable the {+driver-short+}'s
 that ensures compatibility and consistent presentation across most operating
 systems, applications, and language character sets.
 
+.. warning::
+
+   There is a bug in Node v22.7.0 that can convert data to incorrect UTF-8,
+   resulting in invalid data being written to the database.
+
 If you *enable* validation, the driver throws an error when it attempts to
 convert data that contains invalid UTF-8 characters. The validation adds
 processing overhead since it needs to check the data.
@@ -26,14 +31,15 @@ If you *disable* validation, your application avoids the validation processing
 overhead, but cannot guarantee consistent presentation of invalid UTF-8 data.
 
 By default, the driver enables UTF-8 validation on data from MongoDB. 
-It checks incoming strings for any characters that are not encoded in a 
-valid UTF-8 format when it transfers data from MongoDB to your application.
+It checks incoming documents for any characters that are not encoded in a 
+valid UTF-8 format when it parses data sent from MongoDB to your application.
 
 .. note::
 
-   The current version of the {+driver-short+} automatically substitutes
-   invalid UTF-8 characters with alternate valid UTF-8 ones before
-   validation when you send data to MongoDB. Therefore, the validation
+   The current version of the {+driver-short+} automatically substitutes invalid
+   `lone surrogates <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#utf-16_characters_unicode_code_points_and_grapheme_clusters>`__
+   with the `replacement character <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toWellFormed>`__ 
+   before validation when you send data to MongoDB. Therefore, the validation
    only throws an error when the setting is enabled and the driver
    receives invalid UTF-8 document data from MongoDB.
 

--- a/source/fundamentals/bson/utf8-validation.txt
+++ b/source/fundamentals/bson/utf8-validation.txt
@@ -18,11 +18,6 @@ In this guide, you can learn how to enable or disable the {+driver-short+}'s
 that ensures compatibility and consistent presentation across most operating
 systems, applications, and language character sets.
 
-.. warning::
-
-   There is a bug in Node v22.7.0 that can convert data to incorrect UTF-8,
-   resulting in invalid data being written to the database.
-
 If you *enable* validation, the driver throws an error when it attempts to
 convert data that contains invalid UTF-8 characters. The validation adds
 processing overhead since it needs to check the data.


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-43242>
Staging - <https://deploy-preview-908--docs-node.netlify.app/fundamentals/bson/utf8-validation/>

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
