### PR TITLE
[v6.4] DOCSP-46758 Change Run Command page title (#1009)

### DIFF
--- a/source/fundamentals/run-command.txt
+++ b/source/fundamentals/run-command.txt
@@ -1,8 +1,8 @@
 .. _node-run-command:
 
-=============
+==============
 Run a Command
-=============
+==============
 
 .. contents:: On this page
    :local:

--- a/source/usage-examples/command.txt
+++ b/source/usage-examples/command.txt
@@ -7,9 +7,9 @@
 .. meta::
    :keywords: code example, multiple, modify, customize, debug
 
-=============
-Run a Command
-=============
+=====================
+Run a Command Example
+=====================
 
 You can execute database commands by using the
 `command() <{+api+}/classes/Db.html#command>`__ method on a ``Db``


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v6.4`:
 - [DOCSP-46758 Change Run Command page title (#1009)](https://github.com/mongodb/docs-node/pull/1009)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)