### PR TITLE
[Node] Bug fix: Add v to version numbers

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -1,6 +1,6 @@
 define: prefix docs/drivers/node
 define: base https://www.mongodb.com/${prefix}
-define: versions v3.6 v3.7 v4.0 v4.1 v4.2 v4.3 v4.4 v4.5 v4.6 v4.7 v4.8 v4.9 v4.10 v4.11 v4.12 v4.13 v4.14 v4.15 v4.16 v4.17 v5.0 v5.1 v5.2 v5.3 v5.4 v5.5 v5.6 v5.7 v5.8 v5.9 v6.0 v6.1 v6.2 v6.3 v6.4 v6.5 v6.6 v6.7 v6.8 v6.9 v6.10 v6.11 v6.12 6.13 6.14 6.15 6.16 master
+define: versions v3.6 v3.7 v4.0 v4.1 v4.2 v4.3 v4.4 v4.5 v4.6 v4.7 v4.8 v4.9 v4.10 v4.11 v4.12 v4.13 v4.14 v4.15 v4.16 v4.17 v5.0 v5.1 v5.2 v5.3 v5.4 v5.5 v5.6 v5.7 v5.8 v5.9 v6.0 v6.1 v6.2 v6.3 v6.4 v6.5 v6.6 v6.7 v6.8 v6.9 v6.10 v6.11 v6.12 v6.13 v6.14 v6.15 v6.16 master
 
 symlink: current -> master
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - N/A

Versions 6.13-6.15 will need separate backports so they don't include the newer versions.

### Staging Links
<!-- start insert-links -->
No pages to preview
<!-- end insert-links -->

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
- [ ] Are the page titles greater than 20 characters long and [SEO relevant](https://docs.google.com/spreadsheets/d/1Wkt0-5z04KmcMNscN5bjUKnzwWAtMq9VESp-Lz6r2o8/edit?usp=sharing)?
