### PR TITLE
Fix redirects for v6.13

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -1,6 +1,6 @@
 define: prefix docs/drivers/node
 define: base https://www.mongodb.com/${prefix}
-define: versions v3.6 v3.7 v4.0 v4.1 v4.2 v4.3 v4.4 v4.5 v4.6 v4.7 v4.8 v4.9 v4.10 v4.11 v4.12 v4.13 v4.14 v4.15 v4.16 v4.17 v5.0 v5.1 v5.2 v5.3 v5.4 v5.5 v5.6 v5.7 v5.8 v5.9 v6.0 v6.1 v6.2 v6.3 v6.4 v6.5 v6.6 v6.7 v6.8 v6.9 v6.10 v6.11 v6.12 6.13 master
+define: versions v3.6 v3.7 v4.0 v4.1 v4.2 v4.3 v4.4 v4.5 v4.6 v4.7 v4.8 v4.9 v4.10 v4.11 v4.12 v4.13 v4.14 v4.15 v4.16 v4.17 v5.0 v5.1 v5.2 v5.3 v5.4 v5.5 v5.6 v5.7 v5.8 v5.9 v6.0 v6.1 v6.2 v6.3 v6.4 v6.5 v6.6 v6.7 v6.8 v6.9 v6.10 v6.11 v6.12 v6.13 master
 
 symlink: current -> master
 


### PR DESCRIPTION
Backport of https://github.com/mongodb/docs-node/pull/1103 to v6.13