### PR TITLE
[v6.17] DOCSP-41784 Support for Explicit Resource Management  (#1165)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -5,6 +5,9 @@
   // the branches available to backport to
   "targetBranchChoices": [
     "master",
+    "v6.17",
+    "v6.16",
+    "v6.15",
     "v6.14",
     "v6.13",
     "v6.12",

--- a/source/connect/mongoclient.txt
+++ b/source/connect/mongoclient.txt
@@ -119,6 +119,8 @@ verify that the connection is successful:
    Call the ``MongoClient.connect()`` method explicitly if you want to verify that the
    connection is successful.
 
+.. include:: /includes/explicit-resource-management.rst
+
 To learn more about the {+stable-api+} feature, see the :ref:`{+stable-api+} page
 <nodejs-stable-api>`.
 

--- a/source/crud/query/cursor.txt
+++ b/source/crud/query/cursor.txt
@@ -170,6 +170,8 @@ and the {+mdb-server+}:
    :start-after: start close cursor example
    :end-before: end close cursor example
 
+.. include:: /includes/explicit-resource-management.rst
+
 Abort
 ~~~~~
 

--- a/source/crud/transactions.txt
+++ b/source/crud/transactions.txt
@@ -181,6 +181,8 @@ the Core API:
       const session = client1.startSession();
       client2.db('myDB').collection('myColl').insertOne({ name: 'Jane Eyre' }, { session });
 
+.. include:: /includes/explicit-resource-management.rst
+  
 To see a fully runnable example that uses this API, see the
 :ref:`node-usage-core-txn` usage example. 
 

--- a/source/crud/transactions/transaction-core.txt
+++ b/source/crud/transactions/transaction-core.txt
@@ -148,6 +148,8 @@ This example code performs a transaction through the following actions:
    :start-after: start placeOrder
    :end-before: end placeOrder
 
+.. include:: /includes/explicit-resource-management.rst
+
 .. _nodejs-transaction-example-payment-result:
 
 Transaction Results
@@ -165,7 +167,7 @@ order ``_id`` appended to the orders field:
      "_id": 98765,
      "orders": [
        "61dc..."
-     ]
+     ] 
    }
 
 The ``inventory`` collection contains updated quantities for the

--- a/source/includes/explicit-resource-management.rst
+++ b/source/includes/explicit-resource-management.rst
@@ -1,0 +1,7 @@
+.. tip:: Explicit Resource Management 
+
+    The {+driver-short+} natively supports explicit resource management for
+    ``MongoClient``, ``ClientSession``, ``ChangeStreams``, and cursors. This
+    feature is experimental and subject to change. To learn how to use explicit
+    resource management, see the `v6.9 Release Notes.
+    <https://github.com/mongodb/node-mongodb-native/releases/tag/v6.9.0>`__

--- a/source/monitoring-and-logging/change-streams.txt
+++ b/source/monitoring-and-logging/change-streams.txt
@@ -135,6 +135,8 @@ the ``insertDB`` database and prints change events as they occur:
    :language: javascript
    :linenos:
 
+.. include:: /includes/explicit-resource-management.rst
+   
 When you run this code and then make a change to the ``haikus``
 collection, such as performing an insert or delete operation, you can
 see the change event document printed in your terminal.


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v6.17`:
 - [DOCSP-41784 Support for Explicit Resource Management  (#1165)](https://github.com/mongodb/docs-node/pull/1165)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)