### PR TITLE
[v6.11] DOCSP-51959 Add a warning about tryNext bug to all change stream manual iteration examples (#1189)

### DIFF
--- a/source/includes/try-next-warning.rst
+++ b/source/includes/try-next-warning.rst
@@ -1,0 +1,6 @@
+.. warning::
+
+   The `tryNext() <{+api+}/classes/ChangeStream.html#tryNext>`_ method does not
+   automatically update the change stream's `resumeToken.
+   <{+api+}/classes/ChangeStream.html#resumeToken>`_ If you require an updated
+   ``resumeToken``, use the ``next()`` method.

--- a/source/monitoring-and-logging/change-streams.txt
+++ b/source/monitoring-and-logging/change-streams.txt
@@ -44,6 +44,8 @@ section for more information on the settings you can configure with this object.
 The ``watch()`` method returns an instance of a `ChangeStream <{+api+}/classes/ChangeStream.html>`__. You can read events from
 change streams by iterating over them or listening for events. 
 
+.. include:: /includes/changestream-paradigm-warning.rst
+
 Select the tab that corresponds to the way you want to
 read events from the change stream:
 
@@ -72,6 +74,7 @@ read events from the change stream:
       - ``next()`` to request the next document in the stream
       - ``close()`` to close the ChangeStream
 
+      .. include:: /includes/try-next-warning.rst
 
    .. tab::
       :tabid: Event
@@ -98,7 +101,7 @@ read events from the change stream:
 
          changeStream.close();
 
-.. include:: /includes/changestream-paradigm-warning.rst
+.. _node-usage-watch:
 
 Examples
 --------


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v6.11`:
 - [DOCSP-51959 Add a warning about tryNext bug to all change stream manual iteration examples (#1189)](https://github.com/mongodb/docs-node/pull/1189)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)